### PR TITLE
Swap canonical URLs to live Netlify site

### DIFF
--- a/blueprint-landing.html
+++ b/blueprint-landing.html
@@ -5,18 +5,18 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <title>The Architect's Blueprint — PKFIT</title>
   <meta name="description" content="A 30-day system that diagnoses what's stalling your physique, corrects it in structured phases, rewires the identity, and locks the new baseline in.">
-  <link rel="canonical" href="https://pkfit-architect.netlify.app/">
+  <link rel="canonical" href="https://superb-bublanina-f12222.netlify.app/">
 
   <meta property="og:type" content="website">
-  <meta property="og:url" content="https://pkfit-architect.netlify.app/">
+  <meta property="og:url" content="https://superb-bublanina-f12222.netlify.app/">
   <meta property="og:title" content="The Architect's Blueprint — PKFIT">
   <meta property="og:description" content="A 30-day system that diagnoses what's stalling your physique, corrects it in structured phases, rewires the identity, and locks the new baseline in.">
-  <meta property="og:image" content="https://pkfit-architect.netlify.app/assets/img/og.png">
+  <meta property="og:image" content="https://superb-bublanina-f12222.netlify.app/assets/img/og.png">
 
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:title" content="The Architect's Blueprint — PKFIT">
   <meta name="twitter:description" content="A 30-day system that diagnoses what's stalling your physique, corrects it in structured phases, rewires the identity, and locks the new baseline in.">
-  <meta name="twitter:image" content="https://pkfit-architect.netlify.app/assets/img/og.png">
+  <meta name="twitter:image" content="https://superb-bublanina-f12222.netlify.app/assets/img/og.png">
 
   <link rel="icon" type="image/png" href="/assets/img/favicon.png">
   <link rel="apple-touch-icon" href="/assets/img/apple-touch-icon.png">


### PR DESCRIPTION
## Summary

Swaps the canonical / Open Graph / Twitter URLs in `blueprint-landing.html` from the `pkfit-architect.netlify.app` placeholder (which was never a real domain) to the live Netlify slug `superb-bublanina-f12222.netlify.app`.

Scope is intentionally minimal — 4 string replacements, no other changes.

```
-  <link rel="canonical" href="https://pkfit-architect.netlify.app/">
+  <link rel="canonical" href="https://superb-bublanina-f12222.netlify.app/">
-  <meta property="og:url" content="https://pkfit-architect.netlify.app/">
+  <meta property="og:url" content="https://superb-bublanina-f12222.netlify.app/">
-  <meta property="og:image" content="https://pkfit-architect.netlify.app/assets/img/og.png">
+  <meta property="og:image" content="https://superb-bublanina-f12222.netlify.app/assets/img/og.png">
-  <meta name="twitter:image" content="https://pkfit-architect.netlify.app/assets/img/og.png">
+  <meta name="twitter:image" content="https://superb-bublanina-f12222.netlify.app/assets/img/og.png">
```

## Heads-up: you probably want to rename the site first

`superb-bublanina-f12222` is Netlify's auto-generated slug. It's ugly in search results and OG previews. If you plan to rename the site (e.g. to `pkfit-architect` or `pkfit-blueprint`), do it **before** merging — otherwise we burn another swap branch when you rename.

**To rename:** Netlify → site → **Site configuration → Site details → Change site name**. Takes 10 seconds. Then comment here with the new slug and I'll update this branch in one commit before merge.

If you're happy with `superb-bublanina-f12222.netlify.app` as the final URL (until the custom domain arrives), merge as-is.

## Test plan

- [x] View-source on the deployed page shows the new URLs in canonical / og / twitter tags.
- [x] Facebook / LinkedIn / Twitter OG debugger can fetch the page and resolve the image.
- [x] Google Rich Results Test still validates the JSON-LD Product schema.
