### PR TITLE
Add iOS 26 Liquid Glass design system components

### DIFF
--- a/components/iOS.jsx
+++ b/components/iOS.jsx
@@ -1,0 +1,329 @@
+// iOS.jsx — iOS 26 (Liquid Glass) device frame component library
+// Exports: IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard
+
+// ─────────────────────────────────────────────────────────────
+// Status bar
+// ─────────────────────────────────────────────────────────────
+function IOSStatusBar({ dark = false, time = '9:41' }) {
+  const c = dark ? '#fff' : '#000';
+  return (
+    <div style={{
+      display: 'flex', gap: 154, alignItems: 'center', justifyContent: 'center',
+      padding: '21px 24px 19px', boxSizing: 'border-box',
+      position: 'relative', zIndex: 20, width: '100%',
+    }}>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', paddingTop: 1.5 }}>
+        <span style={{
+          fontFamily: '-apple-system, "SF Pro", system-ui', fontWeight: 590,
+          fontSize: 17, lineHeight: '22px', color: c,
+        }}>{time}</span>
+      </div>
+      <div style={{ flex: 1, height: 22, display: 'flex', alignItems: 'center', justifyContent: 'center', gap: 7, paddingTop: 1, paddingRight: 1 }}>
+        <svg width="19" height="12" viewBox="0 0 19 12">
+          <rect x="0" y="7.5" width="3.2" height="4.5" rx="0.7" fill={c}/>
+          <rect x="4.8" y="5" width="3.2" height="7" rx="0.7" fill={c}/>
+          <rect x="9.6" y="2.5" width="3.2" height="9.5" rx="0.7" fill={c}/>
+          <rect x="14.4" y="0" width="3.2" height="12" rx="0.7" fill={c}/>
+        </svg>
+        <svg width="17" height="12" viewBox="0 0 17 12">
+          <path d="M8.5 3.2C10.8 3.2 12.9 4.1 14.4 5.6L15.5 4.5C13.7 2.7 11.2 1.5 8.5 1.5C5.8 1.5 3.3 2.7 1.5 4.5L2.6 5.6C4.1 4.1 6.2 3.2 8.5 3.2Z" fill={c}/>
+          <path d="M8.5 6.8C9.9 6.8 11.1 7.3 12 8.2L13.1 7.1C11.8 5.9 10.2 5.1 8.5 5.1C6.8 5.1 5.2 5.9 3.9 7.1L5 8.2C5.9 7.3 7.1 6.8 8.5 6.8Z" fill={c}/>
+          <circle cx="8.5" cy="10.5" r="1.5" fill={c}/>
+        </svg>
+        <svg width="27" height="13" viewBox="0 0 27 13">
+          <rect x="0.5" y="0.5" width="23" height="12" rx="3.5" stroke={c} strokeOpacity="0.35" fill="none"/>
+          <rect x="2" y="2" width="20" height="9" rx="2" fill={c}/>
+          <path d="M25 4.5V8.5C25.8 8.2 26.5 7.2 26.5 6.5C26.5 5.8 25.8 4.8 25 4.5Z" fill={c} fillOpacity="0.4"/>
+        </svg>
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Liquid glass pill — blur + tint + shine
+// ─────────────────────────────────────────────────────────────
+function IOSGlassPill({ children, dark = false, style = {} }) {
+  return (
+    <div style={{
+      height: 44, minWidth: 44, borderRadius: 9999,
+      position: 'relative', overflow: 'hidden',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      boxShadow: dark
+        ? '0 2px 6px rgba(0,0,0,0.35), 0 6px 16px rgba(0,0,0,0.2)'
+        : '0 1px 3px rgba(0,0,0,0.07), 0 3px 10px rgba(0,0,0,0.06)',
+      ...style,
+    }}>
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.28)' : 'rgba(255,255,255,0.5)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 9999,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15), inset -1px -1px 1px rgba(255,255,255,0.08)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+      }} />
+      <div style={{ position: 'relative', zIndex: 1, display: 'flex', alignItems: 'center', padding: '0 4px' }}>
+        {children}
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Navigation bar — glass pills + large title
+// ─────────────────────────────────────────────────────────────
+function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
+  const muted = dark ? 'rgba(255,255,255,0.6)' : '#404040';
+  const text = dark ? '#fff' : '#000';
+  const pillIcon = (content) => (
+    <IOSGlassPill dark={dark}>
+      <div style={{ width: 36, height: 36, display: 'flex', alignItems: 'center', justifyContent: 'center' }}>
+        {content}
+      </div>
+    </IOSGlassPill>
+  );
+  return (
+    <div style={{
+      display: 'flex', flexDirection: 'column', gap: 10,
+      paddingTop: 62, paddingBottom: 10, position: 'relative', zIndex: 5,
+    }}>
+      <div style={{
+        display: 'flex', alignItems: 'center', justifyContent: 'space-between',
+        padding: '0 16px',
+      }}>
+        {pillIcon(
+          <svg width="12" height="20" viewBox="0 0 12 20" fill="none" style={{ marginLeft: -1 }}>
+            <path d="M10 2L2 10l8 8" stroke={muted} strokeWidth="2.5" strokeLinecap="round" strokeLinejoin="round"/>
+          </svg>
+        )}
+        {trailingIcon && pillIcon(
+          <svg width="22" height="6" viewBox="0 0 22 6">
+            <circle cx="3" cy="3" r="2.5" fill={muted}/>
+            <circle cx="11" cy="3" r="2.5" fill={muted}/>
+            <circle cx="19" cy="3" r="2.5" fill={muted}/>
+          </svg>
+        )}
+      </div>
+      <div style={{
+        padding: '0 16px',
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 34, fontWeight: 700, lineHeight: '41px',
+        color: text, letterSpacing: 0.4,
+      }}>{title}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Grouped list (inset card, r:26) + row (52px)
+// ─────────────────────────────────────────────────────────────
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+  const text = dark ? '#fff' : '#000';
+  const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
+  const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
+  return (
+    <div style={{
+      display: 'flex', alignItems: 'center', minHeight: 52,
+      padding: '0 16px', position: 'relative',
+      fontFamily: '-apple-system, system-ui', fontSize: 17,
+      letterSpacing: -0.43,
+    }}>
+      {icon && (
+        <div style={{
+          width: 30, height: 30, borderRadius: 7, background: icon,
+          marginRight: 12, flexShrink: 0,
+        }} />
+      )}
+      <div style={{ flex: 1, color: text }}>{title}</div>
+      {detail && <span style={{ color: sec, marginRight: 6 }}>{detail}</span>}
+      {chevron && (
+        <svg width="8" height="14" viewBox="0 0 8 14" style={{ flexShrink: 0 }}>
+          <path d="M1 1l6 6-6 6" stroke={ter} strokeWidth="2" fill="none" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      )}
+      {!isLast && (
+        <div style={{
+          position: 'absolute', bottom: 0, right: 0,
+          left: icon ? 58 : 16, height: 0.5, background: sep,
+        }} />
+      )}
+    </div>
+  );
+}
+
+function IOSList({ header, children, dark = false }) {
+  const hc = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
+  const bg = dark ? '#1C1C1E' : '#fff';
+  return (
+    <div>
+      {header && (
+        <div style={{
+          fontFamily: '-apple-system, system-ui', fontSize: 13,
+          color: hc, textTransform: 'uppercase',
+          padding: '8px 36px 6px', letterSpacing: -0.08,
+        }}>{header}</div>
+      )}
+      <div style={{
+        background: bg, borderRadius: 26,
+        margin: '0 16px', overflow: 'hidden',
+      }}>{children}</div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Device frame
+// ─────────────────────────────────────────────────────────────
+function IOSDevice({
+  children, width = 402, height = 874, dark = false,
+  title, keyboard = false,
+}) {
+  return (
+    <div style={{
+      width, height, borderRadius: 48, overflow: 'hidden',
+      position: 'relative', background: dark ? '#000' : '#F2F2F7',
+      boxShadow: '0 40px 80px rgba(0,0,0,0.18), 0 0 0 1px rgba(0,0,0,0.12)',
+      fontFamily: '-apple-system, system-ui, sans-serif',
+      WebkitFontSmoothing: 'antialiased',
+    }}>
+      {/* dynamic island */}
+      <div style={{
+        position: 'absolute', top: 11, left: '50%', transform: 'translateX(-50%)',
+        width: 126, height: 37, borderRadius: 24, background: '#000', zIndex: 50,
+      }} />
+      {/* status bar */}
+      <div style={{ position: 'absolute', top: 0, left: 0, right: 0, zIndex: 10 }}>
+        <IOSStatusBar dark={dark} />
+      </div>
+      {/* nav + content */}
+      <div style={{ height: '100%', display: 'flex', flexDirection: 'column' }}>
+        {title !== undefined && <IOSNavBar title={title} dark={dark} />}
+        <div style={{ flex: 1, overflow: 'auto' }}>{children}</div>
+        {keyboard && <IOSKeyboard dark={dark} />}
+      </div>
+      {/* home indicator */}
+      <div style={{
+        position: 'absolute', bottom: 0, left: 0, right: 0, zIndex: 60,
+        height: 34, display: 'flex', justifyContent: 'center', alignItems: 'flex-end',
+        paddingBottom: 8, pointerEvents: 'none',
+      }}>
+        <div style={{
+          width: 139, height: 5, borderRadius: 100,
+          background: dark ? 'rgba(255,255,255,0.7)' : 'rgba(0,0,0,0.25)',
+        }} />
+      </div>
+    </div>
+  );
+}
+
+// ─────────────────────────────────────────────────────────────
+// Keyboard — iOS 26 liquid glass
+// ─────────────────────────────────────────────────────────────
+function IOSKeyboard({ dark = false }) {
+  const glyph = dark ? 'rgba(255,255,255,0.7)' : '#595959';
+  const sugg = dark ? 'rgba(255,255,255,0.6)' : '#333';
+  const keyBg = dark ? 'rgba(255,255,255,0.22)' : 'rgba(255,255,255,0.85)';
+
+  const icons = {
+    shift: <svg width="19" height="17" viewBox="0 0 19 17"><path d="M9.5 1L1 9.5h4.5V16h8V9.5H18L9.5 1z" fill={glyph}/></svg>,
+    del:   <svg width="23" height="17" viewBox="0 0 23 17"><path d="M7 1h13a2 2 0 012 2v11a2 2 0 01-2 2H7l-6-7.5L7 1z" fill="none" stroke={glyph} strokeWidth="1.6" strokeLinejoin="round"/><path d="M10 5l7 7M17 5l-7 7" stroke={glyph} strokeWidth="1.6" strokeLinecap="round"/></svg>,
+    ret:   <svg width="20" height="14" viewBox="0 0 20 14"><path d="M18 1v6H4m0 0l4-4M4 7l4 4" fill="none" stroke="#fff" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round"/></svg>,
+  };
+
+  const key = (content, { w, flex, ret, fs = 25, k } = {}) => (
+    <div key={k} style={{
+      height: 42, borderRadius: 8.5,
+      flex: flex ? 1 : undefined, width: w, minWidth: 0,
+      background: ret ? '#08f' : keyBg,
+      boxShadow: '0 1px 0 rgba(0,0,0,0.075)',
+      display: 'flex', alignItems: 'center', justifyContent: 'center',
+      fontFamily: '-apple-system, "SF Compact", system-ui',
+      fontSize: fs, fontWeight: 458, color: ret ? '#fff' : glyph,
+    }}>{content}</div>
+  );
+
+  const row = (keys, pad = 0) => (
+    <div style={{ display: 'flex', gap: 6.5, justifyContent: 'center', padding: `0 ${pad}px` }}>
+      {keys.map(l => key(l, { flex: true, k: l }))}
+    </div>
+  );
+
+  return (
+    <div style={{
+      position: 'relative', zIndex: 15, borderRadius: 27, overflow: 'hidden',
+      padding: '11px 0 2px',
+      display: 'flex', flexDirection: 'column', alignItems: 'center',
+      boxShadow: dark
+        ? '0 -2px 20px rgba(0,0,0,0.09)'
+        : '0 -1px 6px rgba(0,0,0,0.018), 0 -3px 20px rgba(0,0,0,0.012)',
+    }}>
+      {/* liquid glass bg */}
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        backdropFilter: 'blur(12px) saturate(180%)',
+        WebkitBackdropFilter: 'blur(12px) saturate(180%)',
+        background: dark ? 'rgba(120,120,128,0.14)' : 'rgba(255,255,255,0.25)',
+      }} />
+      <div style={{
+        position: 'absolute', inset: 0, borderRadius: 27,
+        boxShadow: dark
+          ? 'inset 1.5px 1.5px 1px rgba(255,255,255,0.15)'
+          : 'inset 1.5px 1.5px 1px rgba(255,255,255,0.7), inset -1px -1px 1px rgba(255,255,255,0.4)',
+        border: dark ? '0.5px solid rgba(255,255,255,0.15)' : '0.5px solid rgba(0,0,0,0.06)',
+        pointerEvents: 'none',
+      }} />
+
+      {/* autocorrect bar */}
+      <div style={{
+        display: 'flex', gap: 20, alignItems: 'center',
+        padding: '8px 22px 13px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {['"The"', 'the', 'to'].map((w, i) => (
+          <React.Fragment key={i}>
+            {i > 0 && <div style={{ width: 1, height: 25, background: '#ccc', opacity: 0.3 }} />}
+            <div style={{
+              flex: 1, textAlign: 'center',
+              fontFamily: '-apple-system, system-ui', fontSize: 17,
+              color: sugg, letterSpacing: -0.43, lineHeight: '22px',
+            }}>{w}</div>
+          </React.Fragment>
+        ))}
+      </div>
+
+      {/* key layout */}
+      <div style={{
+        display: 'flex', flexDirection: 'column', gap: 13,
+        padding: '0 6.5px', width: '100%', boxSizing: 'border-box',
+        position: 'relative',
+      }}>
+        {row(['q','w','e','r','t','y','u','i','o','p'])}
+        {row(['a','s','d','f','g','h','j','k','l'], 20)}
+        <div style={{ display: 'flex', gap: 14.25, alignItems: 'center' }}>
+          {key(icons.shift, { w: 45, k: 'shift' })}
+          <div style={{ display: 'flex', gap: 6.5, flex: 1 }}>
+            {['z','x','c','v','b','n','m'].map(l => key(l, { flex: true, k: l }))}
+          </div>
+          {key(icons.del, { w: 45, k: 'del' })}
+        </div>
+        <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+          {key('ABC', { w: 92.25, fs: 18, k: 'abc' })}
+          {key('', { flex: true, k: 'space' })}
+          {key(icons.ret, { w: 92.25, ret: true, k: 'ret' })}
+        </div>
+      </div>
+
+      <div style={{ height: 56, width: '100%', position: 'relative' }} />
+    </div>
+  );
+}
+
+Object.assign(window, {
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+});

--- a/components/iOS.jsx
+++ b/components/iOS.jsx
@@ -122,18 +122,23 @@ function IOSNavBar({ title = 'Title', dark = false, trailingIcon = true }) {
 // ─────────────────────────────────────────────────────────────
 // Grouped list (inset card, r:26) + row (52px)
 // ─────────────────────────────────────────────────────────────
-function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false }) {
+function IOSListRow({ title, detail, icon, chevron = true, isLast = false, dark = false, onClick }) {
   const text = dark ? '#fff' : '#000';
   const sec = dark ? 'rgba(235,235,245,0.6)' : 'rgba(60,60,67,0.6)';
   const ter = dark ? 'rgba(235,235,245,0.3)' : 'rgba(60,60,67,0.3)';
   const sep = dark ? 'rgba(84,84,88,0.65)' : 'rgba(60,60,67,0.12)';
   return (
-    <div style={{
-      display: 'flex', alignItems: 'center', minHeight: 52,
-      padding: '0 16px', position: 'relative',
-      fontFamily: '-apple-system, system-ui', fontSize: 17,
-      letterSpacing: -0.43,
-    }}>
+    <div
+      onClick={onClick}
+      style={{
+        display: 'flex', alignItems: 'center', minHeight: 52,
+        padding: '0 16px', position: 'relative',
+        fontFamily: '-apple-system, system-ui', fontSize: 17,
+        letterSpacing: -0.43,
+        cursor: onClick ? 'pointer' : 'default',
+        WebkitTapHighlightColor: 'rgba(0,0,0,0)',
+      }}
+    >
       {icon && (
         <div style={{
           width: 30, height: 30, borderRadius: 7, background: icon,
@@ -324,6 +329,88 @@ function IOSKeyboard({ dark = false }) {
   );
 }
 
+// ─────────────────────────────────────────────────────────────
+// Bottom sheet — slides up over device content
+// ─────────────────────────────────────────────────────────────
+function IOSSheet({ onDismiss, children, dark = false }) {
+  const [revealed, setRevealed] = React.useState(false);
+  const [leaving, setLeaving]   = React.useState(false);
+  const [dragY, setDragY]       = React.useState(0);
+  const startY = React.useRef(null);
+
+  React.useEffect(() => {
+    requestAnimationFrame(() => setRevealed(true));
+  }, []);
+
+  function dismiss() {
+    setLeaving(true);
+    setTimeout(onDismiss, 340);
+  }
+
+  function onTouchStart(e) { startY.current = e.touches[0].clientY; }
+  function onTouchMove(e) {
+    if (startY.current === null) return;
+    const dy = e.touches[0].clientY - startY.current;
+    if (dy > 0) setDragY(dy);
+  }
+  function onTouchEnd() {
+    if (dragY > 80) dismiss(); else setDragY(0);
+    startY.current = null;
+  }
+
+  const isLive = dragY > 0 && !leaving;
+  const ty = leaving ? '100%' : revealed ? `${dragY}px` : '100%';
+
+  return (
+    <div style={{ position: 'absolute', inset: 0, zIndex: 100 }}>
+      {/* backdrop */}
+      <div
+        onClick={dismiss}
+        style={{
+          position: 'absolute', inset: 0,
+          background: 'rgba(0,0,0,0.52)',
+          backdropFilter: 'blur(5px)',
+          WebkitBackdropFilter: 'blur(5px)',
+          opacity: (revealed && !leaving) ? 1 : 0,
+          transition: 'opacity 0.28s ease',
+        }}
+      />
+      {/* sheet */}
+      <div
+        onTouchStart={onTouchStart}
+        onTouchMove={onTouchMove}
+        onTouchEnd={onTouchEnd}
+        style={{
+          position: 'absolute', bottom: 0, left: 0, right: 0,
+          background: dark ? '#1C1C1E' : '#F2F2F7',
+          borderRadius: '26px 26px 0 0',
+          maxHeight: '80%',
+          display: 'flex', flexDirection: 'column',
+          overflow: 'hidden',
+          transform: `translateY(${ty})`,
+          transition: isLive ? 'none' : 'transform 0.36s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+          boxShadow: '0 -8px 40px rgba(0,0,0,0.35)',
+        }}
+      >
+        {/* drag handle */}
+        <div style={{
+          display: 'flex', justifyContent: 'center',
+          padding: '10px 0 6px', flexShrink: 0, cursor: 'ns-resize',
+        }}>
+          <div style={{
+            width: 36, height: 4, borderRadius: 2,
+            background: dark ? 'rgba(255,255,255,0.18)' : 'rgba(0,0,0,0.12)',
+          }} />
+        </div>
+        {/* scrollable body */}
+        <div style={{ overflow: 'auto', flex: 1, WebkitOverflowScrolling: 'touch' }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
 Object.assign(window, {
-  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard,
+  IOSDevice, IOSStatusBar, IOSNavBar, IOSGlassPill, IOSList, IOSListRow, IOSKeyboard, IOSSheet,
 });

--- a/ios-demo.html
+++ b/ios-demo.html
@@ -57,7 +57,7 @@
 
   <div id="root"></div>
 
-  <p class="hint">drag or swipe to navigate</p>
+  <p class="hint">drag or swipe · tap an exercise for form cues</p>
 
   <footer>PKFIT &copy; 2026</footer>
 
@@ -67,14 +67,109 @@
   <script type="text/babel" data-type="module" src="components/iOS.jsx"></script>
 
   <script type="text/babel">
-    const { IOSDevice, IOSList, IOSListRow } = window;
+    const { IOSDevice, IOSList, IOSListRow, IOSSheet } = window;
+
+    const GOLD = '#C8A96E';
+    const WIDTH = 390;
+    const THRESHOLD = 52;
+
+    // ── Exercise database ──────────────────────────────────────
+
+    const EXERCISES = {
+      'Barbell Bench Press': {
+        sets: '4 × 6', load: '@80% 1RM',
+        setup: [
+          'Lie flat — eyes directly under the bar',
+          'Grip slightly wider than shoulder-width',
+          'Pinch shoulder blades together and down',
+          'Plant feet flat and drive them into the floor',
+        ],
+        cues: [
+          'Touch lower chest — elbows at ~45° to torso',
+          'Push the bar back toward the rack, not straight up',
+          'Full lockout on every rep',
+        ],
+        avoid: [
+          'Bouncing the bar off your chest',
+          'Flaring elbows to 90°',
+          'Losing leg drive mid-set',
+        ],
+      },
+      'Incline DB Press': {
+        sets: '3 × 10', load: 'RPE 8',
+        setup: [
+          'Set bench to 30–45°',
+          'Dumbbells at shoulder level, slight wrist rotation',
+          'Feet flat, upper back against pad',
+        ],
+        cues: [
+          'Arc the path — press up and slightly in',
+          'Don\'t lock out fully at the top',
+          '3-second eccentric on every rep',
+        ],
+        avoid: [
+          'Letting elbows flare excessively',
+          'Rushing the lowering phase',
+          'Bench angle above 45° (front delt takes over)',
+        ],
+      },
+      'Overhead Press': {
+        sets: '3 × 8', load: '@70% 1RM',
+        setup: [
+          'Bar resting on front delts, elbows just in front',
+          'Grip just outside shoulder-width',
+          'Brace core hard — squeeze glutes',
+        ],
+        cues: [
+          'Press in a slight arc — bar travels back then up',
+          'Push your head through at lockout',
+          'Re-brace between every rep',
+        ],
+        avoid: [
+          'Pressing straight up without clearing the chin',
+          'Hyperextending the lower back',
+          'Soft core — it compresses the lumbar',
+        ],
+      },
+      'Lateral Raise': {
+        sets: '4 × 15', load: 'To failure',
+        setup: [
+          'Stand tall, slight bend in knees and elbows',
+          'Lean forward 10–15° at the hips',
+          'Thumbs slightly lower than pinkies',
+        ],
+        cues: [
+          'Lead with elbows, not hands',
+          'Stop at shoulder height — no higher',
+          '2-second hold at top, controlled drop',
+        ],
+        avoid: [
+          'Swinging the torso for momentum',
+          'Raising above shoulder height — traps take over',
+          'Straight arms — loses the lateral delt emphasis',
+        ],
+      },
+      'Tricep Pushdown': {
+        sets: '3 × 12', load: 'RPE 8',
+        setup: [
+          'High cable attachment — rope or straight bar',
+          'Elbows pinned to sides — they stay there',
+          'Slight forward lean at the hips',
+        ],
+        cues: [
+          'Full extension at the bottom — squeeze hard',
+          'Control the cable on the return',
+          'Keep wrists neutral throughout',
+        ],
+        avoid: [
+          'Letting elbows flare or travel forward',
+          'Using shoulder momentum to initiate reps',
+          'Partial reps — full ROM or nothing',
+        ],
+      },
+    };
 
     // ── Shared primitives ──────────────────────────────────────
-
-    const GOLD   = '#C8A96E';
-    const DARK   = true;
-    const WIDTH  = 390;
-    const THRESHOLD = 52;
 
     function Label({ children }) {
       return (
@@ -90,8 +185,7 @@
       return (
         <div style={{
           margin: '20px 16px 0',
-          height: 52, borderRadius: 14,
-          background: GOLD,
+          height: 52, borderRadius: 14, background: GOLD,
           display: 'flex', alignItems: 'center', justifyContent: 'center',
           fontFamily: '-apple-system, system-ui',
           fontSize: 17, fontWeight: 700, color: '#080808', letterSpacing: 0.2,
@@ -99,36 +193,114 @@
       );
     }
 
-    function PhaseCard({ days, name, desc, accent = GOLD }) {
+    // ── Exercise detail sheet ──────────────────────────────────
+
+    function SectionHead({ label }) {
       return (
         <div style={{
-          margin: '0 16px 16px', padding: '18px 20px',
-          borderRadius: 20, background: '#1C1C1E',
-        }}>
-          <div style={{
-            fontFamily: '-apple-system, system-ui',
-            fontSize: 11, fontWeight: 600, letterSpacing: 0.8,
-            color: accent, textTransform: 'uppercase', marginBottom: 5,
-          }}>{days}</div>
-          <div style={{
-            fontFamily: '-apple-system, system-ui',
-            fontSize: 19, fontWeight: 700, color: '#fff', marginBottom: 7,
-          }}>{name}</div>
-          <div style={{
-            fontFamily: '-apple-system, system-ui',
-            fontSize: 13, lineHeight: '18px',
-            color: 'rgba(235,235,245,0.55)',
-          }}>{desc}</div>
-        </div>
+          fontFamily: '-apple-system, system-ui',
+          fontSize: 11, fontWeight: 600,
+          letterSpacing: 0.9, textTransform: 'uppercase',
+          color: GOLD, marginBottom: 12,
+        }}>{label}</div>
       );
     }
 
-    // ── Screen 0: Home ─────────────────────────────────────────
+    function ExerciseSheet({ exercise, onDismiss }) {
+      const data = EXERCISES[exercise];
+      if (!data) return null;
+      const liStyle = {
+        fontFamily: '-apple-system, system-ui',
+        fontSize: 15, lineHeight: '21px',
+        color: 'rgba(235,235,245,0.85)',
+      };
+      return (
+        <IOSSheet onDismiss={onDismiss} dark={true}>
+          {/* Header */}
+          <div style={{ padding: '6px 20px 20px' }}>
+            <div style={{
+              fontFamily: '-apple-system, system-ui',
+              fontSize: 22, fontWeight: 700, color: '#fff',
+              marginBottom: 10, lineHeight: '28px',
+            }}>{exercise}</div>
+            <div style={{ display: 'flex', gap: 8 }}>
+              {[data.sets, data.load].map(tag => (
+                <div key={tag} style={{
+                  height: 26, padding: '0 10px',
+                  borderRadius: 8,
+                  background: 'rgba(200,169,110,0.15)',
+                  border: '0.5px solid rgba(200,169,110,0.35)',
+                  display: 'flex', alignItems: 'center',
+                  fontFamily: '-apple-system, system-ui',
+                  fontSize: 12, fontWeight: 600,
+                  color: GOLD, letterSpacing: 0.2,
+                }}>{tag}</div>
+              ))}
+            </div>
+          </div>
+
+          {/* Setup */}
+          <div style={{ padding: '0 20px 20px' }}>
+            <SectionHead label="Setup" />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {data.setup.map((s, i) => (
+                <div key={i} style={{ display: 'flex', gap: 12, alignItems: 'flex-start' }}>
+                  <div style={{
+                    width: 22, height: 22, borderRadius: 11,
+                    background: 'rgba(200,169,110,0.18)',
+                    border: '0.5px solid rgba(200,169,110,0.35)',
+                    flexShrink: 0,
+                    display: 'flex', alignItems: 'center', justifyContent: 'center',
+                    fontFamily: '-apple-system, system-ui',
+                    fontSize: 11, fontWeight: 700, color: GOLD,
+                    marginTop: 1,
+                  }}>{i + 1}</div>
+                  <div style={liStyle}>{s}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div style={{ height: 0.5, background: 'rgba(84,84,88,0.55)', margin: '0 20px 20px' }} />
+
+          {/* Form cues */}
+          <div style={{ padding: '0 20px 20px' }}>
+            <SectionHead label="Form Cues" />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {data.cues.map((c, i) => (
+                <div key={i} style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                  <div style={{ color: GOLD, fontSize: 14, marginTop: 3, flexShrink: 0 }}>◆</div>
+                  <div style={liStyle}>{c}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          {/* Divider */}
+          <div style={{ height: 0.5, background: 'rgba(84,84,88,0.55)', margin: '0 20px 20px' }} />
+
+          {/* Avoid */}
+          <div style={{ padding: '0 20px 40px' }}>
+            <SectionHead label="Avoid" />
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+              {data.avoid.map((a, i) => (
+                <div key={i} style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+                  <div style={{ color: '#FF453A', fontSize: 14, marginTop: 2, flexShrink: 0, fontWeight: 700 }}>✕</div>
+                  <div style={{ ...liStyle, color: 'rgba(235,235,245,0.65)' }}>{a}</div>
+                </div>
+              ))}
+            </div>
+          </div>
+        </IOSSheet>
+      );
+    }
+
+    // ── Screens ────────────────────────────────────────────────
 
     function HomeScreen() {
       return (
         <div style={{ paddingBottom: 64 }}>
-          {/* Progress bar */}
           <div style={{ padding: '0 16px 20px' }}>
             <div style={{
               fontFamily: '-apple-system, system-ui',
@@ -138,44 +310,67 @@
             </div>
             <div style={{ height: 4, background: 'rgba(255,255,255,0.08)', borderRadius: 2 }}>
               <div style={{
-                width: '40%', height: '100%',
+                width: '40%', height: '100%', borderRadius: 2,
                 background: `linear-gradient(90deg, ${GOLD}, #e8c882)`,
-                borderRadius: 2,
               }} />
             </div>
           </div>
 
-          {/* Active phase */}
-          <PhaseCard
-            days="Active · Days 8–16"
-            name="Correction"
-            desc="Attack the weak points. Targeted training that addresses exactly what the diagnosis revealed."
-          />
+          <div style={{
+            margin: '0 16px 16px', padding: '18px 20px',
+            borderRadius: 20, background: '#1C1C1E',
+          }}>
+            <div style={{
+              fontFamily: '-apple-system, system-ui',
+              fontSize: 11, fontWeight: 600, letterSpacing: 0.8,
+              color: GOLD, textTransform: 'uppercase', marginBottom: 5,
+            }}>Active · Days 8–16</div>
+            <div style={{
+              fontFamily: '-apple-system, system-ui',
+              fontSize: 19, fontWeight: 700, color: '#fff', marginBottom: 7,
+            }}>Correction</div>
+            <div style={{
+              fontFamily: '-apple-system, system-ui',
+              fontSize: 13, lineHeight: '18px', color: 'rgba(235,235,245,0.55)',
+            }}>
+              Attack the weak points. Targeted training that addresses exactly what your diagnosis revealed.
+            </div>
+          </div>
 
-          {/* All phases */}
           <IOSList header="Programme" dark={true}>
             <IOSListRow title="Diagnosis"      detail="Complete" icon={GOLD}    dark={true} />
             <IOSListRow title="Correction"     detail="Day 5/9"  icon="#4CAF50" dark={true} />
-            <IOSListRow title="Identity Shift" detail="Locked"   icon="#333"    dark={true} chevron={false} />
-            <IOSListRow title="The Lock"       detail="Locked"   icon="#333"    dark={true} chevron={false} isLast={true} />
+            <IOSListRow title="Identity Shift" detail="Locked"   icon="#2a2a2e" dark={true} chevron={false} />
+            <IOSListRow title="The Lock"       detail="Locked"   icon="#2a2a2e" dark={true} chevron={false} isLast={true} />
           </IOSList>
         </div>
       );
     }
 
-    // ── Screen 1: Session ──────────────────────────────────────
-
-    function SessionScreen() {
+    function SessionScreen({ onExercise }) {
+      const exercises = [
+        'Barbell Bench Press',
+        'Incline DB Press',
+        'Overhead Press',
+        'Lateral Raise',
+        'Tricep Pushdown',
+      ];
+      const details = ['4 × 6', '3 × 10', '3 × 8', '4 × 15', '3 × 12'];
       return (
         <div style={{ paddingBottom: 64 }}>
           <Label>Correction Phase · Push Day</Label>
 
           <IOSList header="Today's Work" dark={true}>
-            <IOSListRow title="Barbell Bench Press" detail="4 × 6"  dark={true} chevron={false} />
-            <IOSListRow title="Incline DB Press"    detail="3 × 10" dark={true} chevron={false} />
-            <IOSListRow title="Overhead Press"      detail="3 × 8"  dark={true} chevron={false} />
-            <IOSListRow title="Lateral Raise"       detail="4 × 15" dark={true} chevron={false} />
-            <IOSListRow title="Tricep Pushdown"     detail="3 × 12" dark={true} chevron={false} isLast={true} />
+            {exercises.map((name, i) => (
+              <IOSListRow
+                key={name}
+                title={name}
+                detail={details[i]}
+                dark={true}
+                isLast={i === exercises.length - 1}
+                onClick={() => onExercise(name)}
+              />
+            ))}
           </IOSList>
 
           <div style={{ height: 16 }} />
@@ -186,11 +381,18 @@
           </IOSList>
 
           <GoldButton label="Start Session" />
+
+          <div style={{
+            margin: '14px 16px 0',
+            fontFamily: '-apple-system, system-ui',
+            fontSize: 12, color: 'rgba(235,235,245,0.3)',
+            textAlign: 'center',
+          }}>
+            Tap any exercise to see form cues
+          </div>
         </div>
       );
     }
-
-    // ── Screen 2: Nutrition ────────────────────────────────────
 
     function NutritionScreen() {
       const macros = [
@@ -199,30 +401,34 @@
         { label: 'Fat',     g: 80,  color: GOLD },
       ];
       const total = macros.reduce((s, m) => s + m.g * (m.label === 'Fat' ? 9 : 4), 0);
-
       return (
         <div style={{ paddingBottom: 64 }}>
           <Label>Correction Phase · Training Day</Label>
 
-          {/* Calorie ring summary */}
           <div style={{
             margin: '0 16px 16px', padding: '20px',
             borderRadius: 20, background: '#1C1C1E',
             display: 'flex', alignItems: 'center', gap: 20,
           }}>
-            <div style={{ textAlign: 'center', minWidth: 80 }}>
-              <div style={{ fontFamily: '-apple-system, system-ui', fontSize: 28, fontWeight: 700, color: GOLD, lineHeight: 1 }}>2,850</div>
-              <div style={{ fontFamily: '-apple-system, system-ui', fontSize: 11, color: 'rgba(235,235,245,0.45)', marginTop: 4 }}>kcal / day</div>
+            <div style={{ textAlign: 'center', minWidth: 76 }}>
+              <div style={{
+                fontFamily: '-apple-system, system-ui',
+                fontSize: 28, fontWeight: 700, color: GOLD, lineHeight: 1,
+              }}>2,850</div>
+              <div style={{
+                fontFamily: '-apple-system, system-ui',
+                fontSize: 11, color: 'rgba(235,235,245,0.4)', marginTop: 5,
+              }}>kcal / day</div>
             </div>
             <div style={{ flex: 1 }}>
               {macros.map(m => (
-                <div key={m.label} style={{ marginBottom: 8 }}>
+                <div key={m.label} style={{ marginBottom: 9 }}>
                   <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
-                    <span style={{ fontFamily: '-apple-system, system-ui', fontSize: 12, color: 'rgba(235,235,245,0.55)' }}>{m.label}</span>
+                    <span style={{ fontFamily: '-apple-system, system-ui', fontSize: 12, color: 'rgba(235,235,245,0.5)' }}>{m.label}</span>
                     <span style={{ fontFamily: '-apple-system, system-ui', fontSize: 12, color: '#fff', fontWeight: 600 }}>{m.g}g</span>
                   </div>
                   <div style={{ height: 3, background: 'rgba(255,255,255,0.08)', borderRadius: 2 }}>
-                    <div style={{ width: `${Math.round((m.g * (m.label === 'Fat' ? 9 : 4) / total) * 100)}%`, height: '100%', background: m.color, borderRadius: 2 }} />
+                    <div style={{ width: `${Math.round(m.g * (m.label === 'Fat' ? 9 : 4) / total * 100)}%`, height: '100%', background: m.color, borderRadius: 2 }} />
                   </div>
                 </div>
               ))}
@@ -230,8 +436,8 @@
           </div>
 
           <IOSList header="Meal Timing" dark={true}>
-            <IOSListRow title="Pre-workout"   detail="60–90 min"   dark={true} chevron={false} />
-            <IOSListRow title="Intra-workout" detail="If >90 min"  dark={true} chevron={false} />
+            <IOSListRow title="Pre-workout"   detail="60–90 min"    dark={true} chevron={false} />
+            <IOSListRow title="Intra-workout" detail="If >90 min"   dark={true} chevron={false} />
             <IOSListRow title="Post-workout"  detail="Within 2 hrs" dark={true} chevron={false} isLast={true} />
           </IOSList>
 
@@ -244,44 +450,50 @@
       );
     }
 
-    // ── Screen 3: Progress ─────────────────────────────────────
-
     function ProgressScreen() {
       return (
         <div style={{ paddingBottom: 64 }}>
           <Label>Week 2 · End of Correction Phase</Label>
 
-          {/* Delta card */}
           <div style={{
             margin: '0 16px 16px', padding: '18px 20px',
             borderRadius: 20, background: '#1C1C1E',
-            display: 'flex', gap: 0,
+            display: 'flex',
           }}>
             {[
-              { label: 'Weight',     value: '183',  unit: 'lbs',  color: '#fff' },
-              { label: '4-wk Δ',    value: '−2.4', unit: 'lbs',  color: '#4CAF50' },
-              { label: 'Strength',   value: '+4.1', unit: '%',    color: GOLD },
+              { label: 'Weight',   value: '183',  unit: 'lbs', color: '#fff' },
+              { label: '4-wk Δ',  value: '−2.4', unit: 'lbs', color: '#4CAF50' },
+              { label: 'Strength', value: '+4.1', unit: '%',   color: GOLD },
             ].map((s, i) => (
-              <div key={i} style={{ flex: 1, textAlign: 'center', borderLeft: i > 0 ? '0.5px solid rgba(255,255,255,0.08)' : 'none' }}>
-                <div style={{ fontFamily: '-apple-system, system-ui', fontSize: 22, fontWeight: 700, color: s.color, lineHeight: 1 }}>
-                  {s.value}<span style={{ fontSize: 13 }}> {s.unit}</span>
+              <div key={i} style={{
+                flex: 1, textAlign: 'center',
+                borderLeft: i > 0 ? '0.5px solid rgba(255,255,255,0.08)' : 'none',
+              }}>
+                <div style={{
+                  fontFamily: '-apple-system, system-ui',
+                  fontSize: 22, fontWeight: 700, color: s.color, lineHeight: 1,
+                }}>
+                  {s.value}<span style={{ fontSize: 12 }}> {s.unit}</span>
                 </div>
-                <div style={{ fontFamily: '-apple-system, system-ui', fontSize: 11, color: 'rgba(235,235,245,0.45)', marginTop: 5 }}>{s.label}</div>
+                <div style={{
+                  fontFamily: '-apple-system, system-ui',
+                  fontSize: 11, color: 'rgba(235,235,245,0.4)', marginTop: 5,
+                }}>{s.label}</div>
               </div>
             ))}
           </div>
 
           <IOSList header="Metrics" dark={true}>
-            <IOSListRow title="Body Fat Est."      detail="18.2%"  dark={true} chevron={false} />
-            <IOSListRow title="Waist"              detail="−1.5 cm" dark={true} chevron={false} />
-            <IOSListRow title="Bench Press 1RM"    detail="102 kg" dark={true} chevron={false} isLast={true} />
+            <IOSListRow title="Body Fat Est."    detail="18.2%"   dark={true} chevron={false} />
+            <IOSListRow title="Waist"            detail="−1.5 cm" dark={true} chevron={false} />
+            <IOSListRow title="Bench 1RM"        detail="102 kg"  dark={true} chevron={false} isLast={true} />
           </IOSList>
 
           <div style={{ height: 16 }} />
 
           <IOSList header="Compliance" dark={true}>
-            <IOSListRow title="Sessions"          detail="9 / 10" dark={true} chevron={false} />
-            <IOSListRow title="Nutrition adherence" detail="85%"  dark={true} chevron={false} isLast={true} />
+            <IOSListRow title="Sessions"            detail="9 / 10" dark={true} chevron={false} />
+            <IOSListRow title="Nutrition adherence" detail="85%"    dark={true} chevron={false} isLast={true} />
           </IOSList>
 
           <GoldButton label="Log Week 2 Check-In" />
@@ -291,15 +503,23 @@
 
     // ── Swipe shell ────────────────────────────────────────────
 
-    function SwipeShell({ screens, width }) {
-      const [current, setCurrent]     = React.useState(0);
-      const [liveOffset, setOffset]   = React.useState(0);
-      const [dragging, setDragging]   = React.useState(false);
+    function SwipeShell({ width }) {
+      const [current, setCurrent]   = React.useState(0);
+      const [liveOffset, setOffset] = React.useState(0);
+      const [dragging, setDragging] = React.useState(false);
+      const [activeEx, setActiveEx] = React.useState(null);
 
-      const touchRef   = React.useRef(null); // { x, y }
-      const lockRef    = React.useRef(null); // 'h' | 'v'
-      const mouseRef   = React.useRef(false);
+      const touchRef    = React.useRef(null);
+      const lockRef     = React.useRef(null);
+      const mouseRef    = React.useRef(false);
       const mouseStartX = React.useRef(0);
+
+      const screens = [
+        { title: 'Blueprint', content: <HomeScreen /> },
+        { title: 'Day 12',    content: <SessionScreen onExercise={setActiveEx} /> },
+        { title: 'Nutrition', content: <NutritionScreen /> },
+        { title: 'Progress',  content: <ProgressScreen /> },
+      ];
 
       function snap(offset) {
         if (offset < -THRESHOLD && current < screens.length - 1) setCurrent(c => c + 1);
@@ -309,48 +529,40 @@
       }
 
       function clamp(dx, idx) {
-        const atStart = idx === 0 && dx > 0;
-        const atEnd   = idx === screens.length - 1 && dx < 0;
-        return (atStart || atEnd) ? dx * 0.22 : dx;
+        const edge = (idx === 0 && dx > 0) || (idx === screens.length - 1 && dx < 0);
+        return edge ? dx * 0.22 : dx;
       }
 
-      // Touch
       function onTouchStart(e) {
+        if (activeEx) return;
         touchRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
         lockRef.current  = null;
       }
-
       function onTouchMove(e) {
-        if (!touchRef.current) return;
+        if (activeEx || !touchRef.current) return;
         const dx = e.touches[0].clientX - touchRef.current.x;
         const dy = e.touches[0].clientY - touchRef.current.y;
-
         if (!lockRef.current) {
           if (Math.abs(dx) > Math.abs(dy) + 6) { lockRef.current = 'h'; setDragging(true); }
           else if (Math.abs(dy) > 6)            { lockRef.current = 'v'; }
         }
-
         if (lockRef.current === 'h') setOffset(clamp(dx, current));
       }
-
       function onTouchEnd() {
         if (lockRef.current === 'h') snap(liveOffset);
-        touchRef.current = null;
-        lockRef.current  = null;
+        touchRef.current = null; lockRef.current = null;
       }
 
-      // Mouse
       function onMouseDown(e) {
-        mouseRef.current  = true;
+        if (activeEx) return;
+        mouseRef.current   = true;
         mouseStartX.current = e.clientX;
         setDragging(true);
       }
-
       function onMouseMove(e) {
         if (!mouseRef.current) return;
         setOffset(clamp(e.clientX - mouseStartX.current, current));
       }
-
       function onMouseUp() {
         if (!mouseRef.current) return;
         mouseRef.current = false;
@@ -362,7 +574,12 @@
       return (
         <IOSDevice dark={true} title={screens[current].title} width={width} height={844}>
           <div
-            style={{ width: '100%', height: '100%', overflow: 'hidden', position: 'relative', userSelect: 'none', cursor: dragging ? 'grabbing' : 'grab' }}
+            style={{
+              width: '100%', height: '100%',
+              overflow: 'hidden', position: 'relative',
+              userSelect: 'none',
+              cursor: activeEx ? 'default' : dragging ? 'grabbing' : 'grab',
+            }}
             onTouchStart={onTouchStart}
             onTouchMove={onTouchMove}
             onTouchEnd={onTouchEnd}
@@ -407,22 +624,18 @@
                 }} />
               ))}
             </div>
+
+            {/* Exercise detail sheet */}
+            {activeEx && (
+              <ExerciseSheet exercise={activeEx} onDismiss={() => setActiveEx(null)} />
+            )}
           </div>
         </IOSDevice>
       );
     }
 
-    // ── App ────────────────────────────────────────────────────
-
-    const SCREENS = [
-      { title: 'Blueprint', content: <HomeScreen /> },
-      { title: 'Day 12',    content: <SessionScreen /> },
-      { title: 'Nutrition', content: <NutritionScreen /> },
-      { title: 'Progress',  content: <ProgressScreen /> },
-    ];
-
     ReactDOM.createRoot(document.getElementById('root')).render(
-      <SwipeShell screens={SCREENS} width={WIDTH} />
+      <SwipeShell width={WIDTH} />
     );
   </script>
 

--- a/ios-demo.html
+++ b/ios-demo.html
@@ -12,14 +12,8 @@
   <style>
     *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
 
-    :root {
-      --bg:   #080808;
-      --gold: #C8A96E;
-      --dim:  rgba(200,169,110,0.15);
-    }
-
     body {
-      background: var(--bg);
+      background: #080808;
       color: #fff;
       font-family: 'DM Mono', monospace;
       min-height: 100vh;
@@ -27,279 +21,409 @@
       flex-direction: column;
       align-items: center;
       padding: 64px 24px 80px;
-      gap: 48px;
+      gap: 40px;
     }
 
-    header {
-      text-align: center;
-    }
-
+    header { text-align: center; }
     header .eyebrow {
-      font-size: 11px;
-      letter-spacing: 0.18em;
-      color: var(--gold);
-      text-transform: uppercase;
-      margin-bottom: 12px;
+      font-size: 11px; letter-spacing: 0.18em;
+      color: #C8A96E; text-transform: uppercase; margin-bottom: 12px;
     }
-
     header h1 {
       font-family: 'Bebas Neue', sans-serif;
       font-size: clamp(36px, 6vw, 56px);
-      letter-spacing: 0.04em;
-      line-height: 1;
+      letter-spacing: 0.04em; line-height: 1;
     }
+    header h1 span { color: #C8A96E; }
 
-    header h1 span { color: var(--gold); }
-
-    header p {
-      margin-top: 12px;
-      font-size: 13px;
-      color: rgba(255,255,255,0.45);
-      letter-spacing: 0.02em;
-    }
-
-    .stage {
-      display: flex;
-      gap: 48px;
-      flex-wrap: wrap;
-      justify-content: center;
-      align-items: flex-start;
-    }
-
-    .label {
-      text-align: center;
-      font-size: 11px;
-      letter-spacing: 0.14em;
-      color: rgba(255,255,255,0.3);
+    .hint {
+      font-size: 11px; letter-spacing: 0.12em;
+      color: rgba(255,255,255,0.2);
       text-transform: uppercase;
-      margin-bottom: 16px;
-    }
-
-    .pill-demo {
-      display: flex;
-      gap: 12px;
-      flex-wrap: wrap;
-      justify-content: center;
-      max-width: 500px;
     }
 
     footer {
-      font-size: 11px;
-      color: rgba(255,255,255,0.2);
-      letter-spacing: 0.06em;
-      text-align: center;
+      font-size: 11px; color: rgba(255,255,255,0.15);
+      letter-spacing: 0.06em; text-align: center;
     }
   </style>
 </head>
 <body>
 
   <header>
-    <div class="eyebrow">Design System Preview</div>
-    <h1>iOS 26 <span>Liquid Glass</span></h1>
-    <p>Components · PKFIT Architect</p>
+    <div class="eyebrow">Design System · Swipe Navigation</div>
+    <h1>PKFIT <span>Blueprint</span></h1>
   </header>
 
   <div id="root"></div>
 
-  <footer>PKFIT &copy; 2026 &mdash; ios-demo.html</footer>
+  <p class="hint">drag or swipe to navigate</p>
 
-  <!-- React + Babel via CDN (dev only, no build step required) -->
+  <footer>PKFIT &copy; 2026</footer>
+
   <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
   <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
   <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
-
-  <!-- iOS component library -->
   <script type="text/babel" data-type="module" src="components/iOS.jsx"></script>
 
-  <!-- Demo app — renders after iOS.jsx registers globals -->
   <script type="text/babel">
-    const { IOSDevice, IOSNavBar, IOSList, IOSListRow, IOSGlassPill } = window;
+    const { IOSDevice, IOSList, IOSListRow } = window;
 
-    // ── Phase card inside the device ──────────────────────────
-    function PhaseCard({ days, name, desc, accent }) {
+    // ── Shared primitives ──────────────────────────────────────
+
+    const GOLD   = '#C8A96E';
+    const DARK   = true;
+    const WIDTH  = 390;
+    const THRESHOLD = 52;
+
+    function Label({ children }) {
       return (
         <div style={{
-          margin: '0 16px 12px',
-          borderRadius: 20,
-          overflow: 'hidden',
-          background: '#1C1C1E',
-          padding: '16px 18px',
+          padding: '0 16px 14px',
+          fontFamily: '-apple-system, system-ui',
+          fontSize: 13, color: 'rgba(235,235,245,0.45)',
+        }}>{children}</div>
+      );
+    }
+
+    function GoldButton({ label }) {
+      return (
+        <div style={{
+          margin: '20px 16px 0',
+          height: 52, borderRadius: 14,
+          background: GOLD,
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontFamily: '-apple-system, system-ui',
+          fontSize: 17, fontWeight: 700, color: '#080808', letterSpacing: 0.2,
+        }}>{label}</div>
+      );
+    }
+
+    function PhaseCard({ days, name, desc, accent = GOLD }) {
+      return (
+        <div style={{
+          margin: '0 16px 16px', padding: '18px 20px',
+          borderRadius: 20, background: '#1C1C1E',
         }}>
           <div style={{
             fontFamily: '-apple-system, system-ui',
-            fontSize: 11, fontWeight: 600,
-            letterSpacing: 0.08,
-            color: accent,
-            textTransform: 'uppercase',
-            marginBottom: 4,
+            fontSize: 11, fontWeight: 600, letterSpacing: 0.8,
+            color: accent, textTransform: 'uppercase', marginBottom: 5,
           }}>{days}</div>
           <div style={{
             fontFamily: '-apple-system, system-ui',
-            fontSize: 17, fontWeight: 700,
-            color: '#fff', marginBottom: 6,
+            fontSize: 19, fontWeight: 700, color: '#fff', marginBottom: 7,
           }}>{name}</div>
           <div style={{
             fontFamily: '-apple-system, system-ui',
             fontSize: 13, lineHeight: '18px',
-            color: 'rgba(235,235,245,0.6)',
+            color: 'rgba(235,235,245,0.55)',
           }}>{desc}</div>
         </div>
       );
     }
 
-    // ── Gold CTA button ───────────────────────────────────────
-    function CTAButton({ label }) {
-      return (
-        <div style={{
-          margin: '4px 16px 24px',
-          height: 52,
-          borderRadius: 14,
-          background: '#C8A96E',
-          display: 'flex', alignItems: 'center', justifyContent: 'center',
-          fontFamily: '-apple-system, system-ui',
-          fontSize: 17, fontWeight: 700,
-          color: '#080808',
-          letterSpacing: 0.2,
-        }}>{label}</div>
-      );
-    }
+    // ── Screen 0: Home ─────────────────────────────────────────
 
-    // ── Full demo ─────────────────────────────────────────────
-    function Demo() {
+    function HomeScreen() {
       return (
-        <div style={{
-          display: 'flex', gap: 48,
-          flexWrap: 'wrap', justifyContent: 'center', alignItems: 'flex-start',
-        }}>
-
-          {/* ── Dark device: Blueprint home screen ── */}
-          <div>
+        <div style={{ paddingBottom: 64 }}>
+          {/* Progress bar */}
+          <div style={{ padding: '0 16px 20px' }}>
             <div style={{
-              textAlign: 'center',
-              fontFamily: 'DM Mono, monospace',
-              fontSize: 11, letterSpacing: '0.14em',
-              color: 'rgba(255,255,255,0.3)',
-              textTransform: 'uppercase',
-              marginBottom: 16,
-            }}>Dark · Home</div>
-
-            <IOSDevice dark={true} title="Blueprint" width={390} height={844}>
-              {/* Greeting */}
+              fontFamily: '-apple-system, system-ui',
+              fontSize: 15, color: 'rgba(235,235,245,0.55)', marginBottom: 10,
+            }}>
+              Day <span style={{ color: GOLD, fontWeight: 700 }}>12</span> of 30
+            </div>
+            <div style={{ height: 4, background: 'rgba(255,255,255,0.08)', borderRadius: 2 }}>
               <div style={{
-                padding: '0 16px 16px',
-                fontFamily: '-apple-system, system-ui',
-                fontSize: 15, color: 'rgba(235,235,245,0.55)',
-              }}>
-                Day <span style={{ color: '#C8A96E', fontWeight: 700 }}>12</span> of 30
-              </div>
-
-              {/* Phases */}
-              <IOSList header="Your Programme" dark={true}>
-                <IOSListRow title="Diagnosis"     detail="Days 1–7"   icon="#C8A96E" dark={true} />
-                <IOSListRow title="Correction"    detail="Days 8–16"  icon="#4CAF50" dark={true} />
-                <IOSListRow title="Identity Shift" detail="Days 17–24" icon="#2196F3" dark={true} />
-                <IOSListRow title="The Lock"      detail="Days 25–30" icon="#9C27B0" dark={true} isLast={true} />
-              </IOSList>
-
-              <div style={{ height: 20 }} />
-
-              {/* Phase cards */}
-              <PhaseCard
-                days="Days 1–7"
-                name="Diagnosis"
-                desc="Audit your body, habits, and baseline. Identify what's actually stalling you."
-                accent="#C8A96E"
-              />
-              <PhaseCard
-                days="Days 8–16 · Current"
-                name="Correction"
-                desc="Attack the weak points. Targeted protocols that address exactly what the diagnosis revealed."
-                accent="#4CAF50"
-              />
-
-              <CTAButton label="View Today's Session →" />
-            </IOSDevice>
-          </div>
-
-          {/* ── Light device: Keyboard demo ── */}
-          <div>
-            <div style={{
-              textAlign: 'center',
-              fontFamily: 'DM Mono, monospace',
-              fontSize: 11, letterSpacing: '0.14em',
-              color: 'rgba(255,255,255,0.3)',
-              textTransform: 'uppercase',
-              marginBottom: 16,
-            }}>Light · Keyboard</div>
-
-            <IOSDevice dark={false} title="Notes" width={390} height={844} keyboard={true}>
-              <div style={{ padding: '0 16px' }}>
-                <IOSList dark={false}>
-                  <IOSListRow title="Today's training notes" detail="Now" icon="#FF9500" dark={false} />
-                  <IOSListRow title="Nutrition log"          detail="2m"  icon="#34C759" dark={false} />
-                  <IOSListRow title="Weekly check-in"        detail="1h"  icon="#007AFF" dark={false} isLast={true} />
-                </IOSList>
-              </div>
-            </IOSDevice>
-          </div>
-
-          {/* ── Pills showcase ── */}
-          <div>
-            <div style={{
-              textAlign: 'center',
-              fontFamily: 'DM Mono, monospace',
-              fontSize: 11, letterSpacing: '0.14em',
-              color: 'rgba(255,255,255,0.3)',
-              textTransform: 'uppercase',
-              marginBottom: 16,
-            }}>Glass Pills</div>
-
-            {/* dark pills on dark bg */}
-            <div style={{
-              background: '#1a1a1e',
-              borderRadius: 24,
-              padding: 24,
-              display: 'flex', gap: 12, flexWrap: 'wrap',
-              justifyContent: 'center', maxWidth: 300,
-            }}>
-              {['Back', 'Share', '···', 'Done'].map(label => (
-                <IOSGlassPill key={label} dark={true} style={{ padding: '0 18px' }}>
-                  <span style={{
-                    fontFamily: '-apple-system, system-ui',
-                    fontSize: 15, fontWeight: 600,
-                    color: '#fff',
-                  }}>{label}</span>
-                </IOSGlassPill>
-              ))}
-            </div>
-
-            <div style={{ height: 16 }} />
-
-            {/* light pills on light bg */}
-            <div style={{
-              background: '#F2F2F7',
-              borderRadius: 24,
-              padding: 24,
-              display: 'flex', gap: 12, flexWrap: 'wrap',
-              justifyContent: 'center', maxWidth: 300,
-            }}>
-              {['Back', 'Share', '···', 'Done'].map(label => (
-                <IOSGlassPill key={label} dark={false} style={{ padding: '0 18px' }}>
-                  <span style={{
-                    fontFamily: '-apple-system, system-ui',
-                    fontSize: 15, fontWeight: 600,
-                    color: '#000',
-                  }}>{label}</span>
-                </IOSGlassPill>
-              ))}
+                width: '40%', height: '100%',
+                background: `linear-gradient(90deg, ${GOLD}, #e8c882)`,
+                borderRadius: 2,
+              }} />
             </div>
           </div>
 
+          {/* Active phase */}
+          <PhaseCard
+            days="Active · Days 8–16"
+            name="Correction"
+            desc="Attack the weak points. Targeted training that addresses exactly what the diagnosis revealed."
+          />
+
+          {/* All phases */}
+          <IOSList header="Programme" dark={true}>
+            <IOSListRow title="Diagnosis"      detail="Complete" icon={GOLD}    dark={true} />
+            <IOSListRow title="Correction"     detail="Day 5/9"  icon="#4CAF50" dark={true} />
+            <IOSListRow title="Identity Shift" detail="Locked"   icon="#333"    dark={true} chevron={false} />
+            <IOSListRow title="The Lock"       detail="Locked"   icon="#333"    dark={true} chevron={false} isLast={true} />
+          </IOSList>
         </div>
       );
     }
 
-    ReactDOM.createRoot(document.getElementById('root')).render(<Demo />);
+    // ── Screen 1: Session ──────────────────────────────────────
+
+    function SessionScreen() {
+      return (
+        <div style={{ paddingBottom: 64 }}>
+          <Label>Correction Phase · Push Day</Label>
+
+          <IOSList header="Today's Work" dark={true}>
+            <IOSListRow title="Barbell Bench Press" detail="4 × 6"  dark={true} chevron={false} />
+            <IOSListRow title="Incline DB Press"    detail="3 × 10" dark={true} chevron={false} />
+            <IOSListRow title="Overhead Press"      detail="3 × 8"  dark={true} chevron={false} />
+            <IOSListRow title="Lateral Raise"       detail="4 × 15" dark={true} chevron={false} />
+            <IOSListRow title="Tricep Pushdown"     detail="3 × 12" dark={true} chevron={false} isLast={true} />
+          </IOSList>
+
+          <div style={{ height: 16 }} />
+
+          <IOSList header="Load Reference" dark={true}>
+            <IOSListRow title="Last session" detail="@77.5 kg" dark={true} chevron={false} />
+            <IOSListRow title="Today target" detail="@80 kg"   dark={true} chevron={false} isLast={true} />
+          </IOSList>
+
+          <GoldButton label="Start Session" />
+        </div>
+      );
+    }
+
+    // ── Screen 2: Nutrition ────────────────────────────────────
+
+    function NutritionScreen() {
+      const macros = [
+        { label: 'Protein', g: 210, color: '#4CAF50' },
+        { label: 'Carbs',   g: 325, color: '#2196F3' },
+        { label: 'Fat',     g: 80,  color: GOLD },
+      ];
+      const total = macros.reduce((s, m) => s + m.g * (m.label === 'Fat' ? 9 : 4), 0);
+
+      return (
+        <div style={{ paddingBottom: 64 }}>
+          <Label>Correction Phase · Training Day</Label>
+
+          {/* Calorie ring summary */}
+          <div style={{
+            margin: '0 16px 16px', padding: '20px',
+            borderRadius: 20, background: '#1C1C1E',
+            display: 'flex', alignItems: 'center', gap: 20,
+          }}>
+            <div style={{ textAlign: 'center', minWidth: 80 }}>
+              <div style={{ fontFamily: '-apple-system, system-ui', fontSize: 28, fontWeight: 700, color: GOLD, lineHeight: 1 }}>2,850</div>
+              <div style={{ fontFamily: '-apple-system, system-ui', fontSize: 11, color: 'rgba(235,235,245,0.45)', marginTop: 4 }}>kcal / day</div>
+            </div>
+            <div style={{ flex: 1 }}>
+              {macros.map(m => (
+                <div key={m.label} style={{ marginBottom: 8 }}>
+                  <div style={{ display: 'flex', justifyContent: 'space-between', marginBottom: 4 }}>
+                    <span style={{ fontFamily: '-apple-system, system-ui', fontSize: 12, color: 'rgba(235,235,245,0.55)' }}>{m.label}</span>
+                    <span style={{ fontFamily: '-apple-system, system-ui', fontSize: 12, color: '#fff', fontWeight: 600 }}>{m.g}g</span>
+                  </div>
+                  <div style={{ height: 3, background: 'rgba(255,255,255,0.08)', borderRadius: 2 }}>
+                    <div style={{ width: `${Math.round((m.g * (m.label === 'Fat' ? 9 : 4) / total) * 100)}%`, height: '100%', background: m.color, borderRadius: 2 }} />
+                  </div>
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <IOSList header="Meal Timing" dark={true}>
+            <IOSListRow title="Pre-workout"   detail="60–90 min"   dark={true} chevron={false} />
+            <IOSListRow title="Intra-workout" detail="If >90 min"  dark={true} chevron={false} />
+            <IOSListRow title="Post-workout"  detail="Within 2 hrs" dark={true} chevron={false} isLast={true} />
+          </IOSList>
+
+          <div style={{ height: 16 }} />
+
+          <IOSList header="Hydration" dark={true}>
+            <IOSListRow title="Daily target" detail="3.5 L" dark={true} chevron={false} isLast={true} />
+          </IOSList>
+        </div>
+      );
+    }
+
+    // ── Screen 3: Progress ─────────────────────────────────────
+
+    function ProgressScreen() {
+      return (
+        <div style={{ paddingBottom: 64 }}>
+          <Label>Week 2 · End of Correction Phase</Label>
+
+          {/* Delta card */}
+          <div style={{
+            margin: '0 16px 16px', padding: '18px 20px',
+            borderRadius: 20, background: '#1C1C1E',
+            display: 'flex', gap: 0,
+          }}>
+            {[
+              { label: 'Weight',     value: '183',  unit: 'lbs',  color: '#fff' },
+              { label: '4-wk Δ',    value: '−2.4', unit: 'lbs',  color: '#4CAF50' },
+              { label: 'Strength',   value: '+4.1', unit: '%',    color: GOLD },
+            ].map((s, i) => (
+              <div key={i} style={{ flex: 1, textAlign: 'center', borderLeft: i > 0 ? '0.5px solid rgba(255,255,255,0.08)' : 'none' }}>
+                <div style={{ fontFamily: '-apple-system, system-ui', fontSize: 22, fontWeight: 700, color: s.color, lineHeight: 1 }}>
+                  {s.value}<span style={{ fontSize: 13 }}> {s.unit}</span>
+                </div>
+                <div style={{ fontFamily: '-apple-system, system-ui', fontSize: 11, color: 'rgba(235,235,245,0.45)', marginTop: 5 }}>{s.label}</div>
+              </div>
+            ))}
+          </div>
+
+          <IOSList header="Metrics" dark={true}>
+            <IOSListRow title="Body Fat Est."      detail="18.2%"  dark={true} chevron={false} />
+            <IOSListRow title="Waist"              detail="−1.5 cm" dark={true} chevron={false} />
+            <IOSListRow title="Bench Press 1RM"    detail="102 kg" dark={true} chevron={false} isLast={true} />
+          </IOSList>
+
+          <div style={{ height: 16 }} />
+
+          <IOSList header="Compliance" dark={true}>
+            <IOSListRow title="Sessions"          detail="9 / 10" dark={true} chevron={false} />
+            <IOSListRow title="Nutrition adherence" detail="85%"  dark={true} chevron={false} isLast={true} />
+          </IOSList>
+
+          <GoldButton label="Log Week 2 Check-In" />
+        </div>
+      );
+    }
+
+    // ── Swipe shell ────────────────────────────────────────────
+
+    function SwipeShell({ screens, width }) {
+      const [current, setCurrent]     = React.useState(0);
+      const [liveOffset, setOffset]   = React.useState(0);
+      const [dragging, setDragging]   = React.useState(false);
+
+      const touchRef   = React.useRef(null); // { x, y }
+      const lockRef    = React.useRef(null); // 'h' | 'v'
+      const mouseRef   = React.useRef(false);
+      const mouseStartX = React.useRef(0);
+
+      function snap(offset) {
+        if (offset < -THRESHOLD && current < screens.length - 1) setCurrent(c => c + 1);
+        else if (offset > THRESHOLD && current > 0)              setCurrent(c => c - 1);
+        setOffset(0);
+        setDragging(false);
+      }
+
+      function clamp(dx, idx) {
+        const atStart = idx === 0 && dx > 0;
+        const atEnd   = idx === screens.length - 1 && dx < 0;
+        return (atStart || atEnd) ? dx * 0.22 : dx;
+      }
+
+      // Touch
+      function onTouchStart(e) {
+        touchRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY };
+        lockRef.current  = null;
+      }
+
+      function onTouchMove(e) {
+        if (!touchRef.current) return;
+        const dx = e.touches[0].clientX - touchRef.current.x;
+        const dy = e.touches[0].clientY - touchRef.current.y;
+
+        if (!lockRef.current) {
+          if (Math.abs(dx) > Math.abs(dy) + 6) { lockRef.current = 'h'; setDragging(true); }
+          else if (Math.abs(dy) > 6)            { lockRef.current = 'v'; }
+        }
+
+        if (lockRef.current === 'h') setOffset(clamp(dx, current));
+      }
+
+      function onTouchEnd() {
+        if (lockRef.current === 'h') snap(liveOffset);
+        touchRef.current = null;
+        lockRef.current  = null;
+      }
+
+      // Mouse
+      function onMouseDown(e) {
+        mouseRef.current  = true;
+        mouseStartX.current = e.clientX;
+        setDragging(true);
+      }
+
+      function onMouseMove(e) {
+        if (!mouseRef.current) return;
+        setOffset(clamp(e.clientX - mouseStartX.current, current));
+      }
+
+      function onMouseUp() {
+        if (!mouseRef.current) return;
+        mouseRef.current = false;
+        snap(liveOffset);
+      }
+
+      const translateX = -(current * width) + liveOffset;
+
+      return (
+        <IOSDevice dark={true} title={screens[current].title} width={width} height={844}>
+          <div
+            style={{ width: '100%', height: '100%', overflow: 'hidden', position: 'relative', userSelect: 'none', cursor: dragging ? 'grabbing' : 'grab' }}
+            onTouchStart={onTouchStart}
+            onTouchMove={onTouchMove}
+            onTouchEnd={onTouchEnd}
+            onMouseDown={onMouseDown}
+            onMouseMove={onMouseMove}
+            onMouseUp={onMouseUp}
+            onMouseLeave={onMouseUp}
+          >
+            {/* Horizontal track */}
+            <div style={{
+              display: 'flex',
+              width: `${screens.length * width}px`,
+              height: '100%',
+              transform: `translateX(${translateX}px)`,
+              transition: dragging ? 'none' : 'transform 0.38s cubic-bezier(0.25, 0.46, 0.45, 0.94)',
+              willChange: 'transform',
+            }}>
+              {screens.map((s, i) => (
+                <div key={i} style={{
+                  width, flexShrink: 0,
+                  height: '100%', overflow: 'auto',
+                  overscrollBehaviorX: 'none',
+                }}>
+                  {s.content}
+                </div>
+              ))}
+            </div>
+
+            {/* Page dots */}
+            <div style={{
+              position: 'absolute', bottom: 18, left: 0, right: 0,
+              display: 'flex', justifyContent: 'center', gap: 6,
+              pointerEvents: 'none',
+            }}>
+              {screens.map((_, i) => (
+                <div key={i} style={{
+                  height: 6,
+                  width: i === current ? 20 : 6,
+                  borderRadius: 3,
+                  background: i === current ? GOLD : 'rgba(255,255,255,0.25)',
+                  transition: 'width 0.3s ease, background 0.3s ease',
+                }} />
+              ))}
+            </div>
+          </div>
+        </IOSDevice>
+      );
+    }
+
+    // ── App ────────────────────────────────────────────────────
+
+    const SCREENS = [
+      { title: 'Blueprint', content: <HomeScreen /> },
+      { title: 'Day 12',    content: <SessionScreen /> },
+      { title: 'Nutrition', content: <NutritionScreen /> },
+      { title: 'Progress',  content: <ProgressScreen /> },
+    ];
+
+    ReactDOM.createRoot(document.getElementById('root')).render(
+      <SwipeShell screens={SCREENS} width={WIDTH} />
+    );
   </script>
 
 </body>

--- a/ios-demo.html
+++ b/ios-demo.html
@@ -1,0 +1,306 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>iOS Design System — PKFIT</title>
+
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Bebas+Neue&family=DM+Mono:wght@300;400;500&display=swap" rel="stylesheet">
+
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+
+    :root {
+      --bg:   #080808;
+      --gold: #C8A96E;
+      --dim:  rgba(200,169,110,0.15);
+    }
+
+    body {
+      background: var(--bg);
+      color: #fff;
+      font-family: 'DM Mono', monospace;
+      min-height: 100vh;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      padding: 64px 24px 80px;
+      gap: 48px;
+    }
+
+    header {
+      text-align: center;
+    }
+
+    header .eyebrow {
+      font-size: 11px;
+      letter-spacing: 0.18em;
+      color: var(--gold);
+      text-transform: uppercase;
+      margin-bottom: 12px;
+    }
+
+    header h1 {
+      font-family: 'Bebas Neue', sans-serif;
+      font-size: clamp(36px, 6vw, 56px);
+      letter-spacing: 0.04em;
+      line-height: 1;
+    }
+
+    header h1 span { color: var(--gold); }
+
+    header p {
+      margin-top: 12px;
+      font-size: 13px;
+      color: rgba(255,255,255,0.45);
+      letter-spacing: 0.02em;
+    }
+
+    .stage {
+      display: flex;
+      gap: 48px;
+      flex-wrap: wrap;
+      justify-content: center;
+      align-items: flex-start;
+    }
+
+    .label {
+      text-align: center;
+      font-size: 11px;
+      letter-spacing: 0.14em;
+      color: rgba(255,255,255,0.3);
+      text-transform: uppercase;
+      margin-bottom: 16px;
+    }
+
+    .pill-demo {
+      display: flex;
+      gap: 12px;
+      flex-wrap: wrap;
+      justify-content: center;
+      max-width: 500px;
+    }
+
+    footer {
+      font-size: 11px;
+      color: rgba(255,255,255,0.2);
+      letter-spacing: 0.06em;
+      text-align: center;
+    }
+  </style>
+</head>
+<body>
+
+  <header>
+    <div class="eyebrow">Design System Preview</div>
+    <h1>iOS 26 <span>Liquid Glass</span></h1>
+    <p>Components · PKFIT Architect</p>
+  </header>
+
+  <div id="root"></div>
+
+  <footer>PKFIT &copy; 2026 &mdash; ios-demo.html</footer>
+
+  <!-- React + Babel via CDN (dev only, no build step required) -->
+  <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+  <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js"></script>
+
+  <!-- iOS component library -->
+  <script type="text/babel" data-type="module" src="components/iOS.jsx"></script>
+
+  <!-- Demo app — renders after iOS.jsx registers globals -->
+  <script type="text/babel">
+    const { IOSDevice, IOSNavBar, IOSList, IOSListRow, IOSGlassPill } = window;
+
+    // ── Phase card inside the device ──────────────────────────
+    function PhaseCard({ days, name, desc, accent }) {
+      return (
+        <div style={{
+          margin: '0 16px 12px',
+          borderRadius: 20,
+          overflow: 'hidden',
+          background: '#1C1C1E',
+          padding: '16px 18px',
+        }}>
+          <div style={{
+            fontFamily: '-apple-system, system-ui',
+            fontSize: 11, fontWeight: 600,
+            letterSpacing: 0.08,
+            color: accent,
+            textTransform: 'uppercase',
+            marginBottom: 4,
+          }}>{days}</div>
+          <div style={{
+            fontFamily: '-apple-system, system-ui',
+            fontSize: 17, fontWeight: 700,
+            color: '#fff', marginBottom: 6,
+          }}>{name}</div>
+          <div style={{
+            fontFamily: '-apple-system, system-ui',
+            fontSize: 13, lineHeight: '18px',
+            color: 'rgba(235,235,245,0.6)',
+          }}>{desc}</div>
+        </div>
+      );
+    }
+
+    // ── Gold CTA button ───────────────────────────────────────
+    function CTAButton({ label }) {
+      return (
+        <div style={{
+          margin: '4px 16px 24px',
+          height: 52,
+          borderRadius: 14,
+          background: '#C8A96E',
+          display: 'flex', alignItems: 'center', justifyContent: 'center',
+          fontFamily: '-apple-system, system-ui',
+          fontSize: 17, fontWeight: 700,
+          color: '#080808',
+          letterSpacing: 0.2,
+        }}>{label}</div>
+      );
+    }
+
+    // ── Full demo ─────────────────────────────────────────────
+    function Demo() {
+      return (
+        <div style={{
+          display: 'flex', gap: 48,
+          flexWrap: 'wrap', justifyContent: 'center', alignItems: 'flex-start',
+        }}>
+
+          {/* ── Dark device: Blueprint home screen ── */}
+          <div>
+            <div style={{
+              textAlign: 'center',
+              fontFamily: 'DM Mono, monospace',
+              fontSize: 11, letterSpacing: '0.14em',
+              color: 'rgba(255,255,255,0.3)',
+              textTransform: 'uppercase',
+              marginBottom: 16,
+            }}>Dark · Home</div>
+
+            <IOSDevice dark={true} title="Blueprint" width={390} height={844}>
+              {/* Greeting */}
+              <div style={{
+                padding: '0 16px 16px',
+                fontFamily: '-apple-system, system-ui',
+                fontSize: 15, color: 'rgba(235,235,245,0.55)',
+              }}>
+                Day <span style={{ color: '#C8A96E', fontWeight: 700 }}>12</span> of 30
+              </div>
+
+              {/* Phases */}
+              <IOSList header="Your Programme" dark={true}>
+                <IOSListRow title="Diagnosis"     detail="Days 1–7"   icon="#C8A96E" dark={true} />
+                <IOSListRow title="Correction"    detail="Days 8–16"  icon="#4CAF50" dark={true} />
+                <IOSListRow title="Identity Shift" detail="Days 17–24" icon="#2196F3" dark={true} />
+                <IOSListRow title="The Lock"      detail="Days 25–30" icon="#9C27B0" dark={true} isLast={true} />
+              </IOSList>
+
+              <div style={{ height: 20 }} />
+
+              {/* Phase cards */}
+              <PhaseCard
+                days="Days 1–7"
+                name="Diagnosis"
+                desc="Audit your body, habits, and baseline. Identify what's actually stalling you."
+                accent="#C8A96E"
+              />
+              <PhaseCard
+                days="Days 8–16 · Current"
+                name="Correction"
+                desc="Attack the weak points. Targeted protocols that address exactly what the diagnosis revealed."
+                accent="#4CAF50"
+              />
+
+              <CTAButton label="View Today's Session →" />
+            </IOSDevice>
+          </div>
+
+          {/* ── Light device: Keyboard demo ── */}
+          <div>
+            <div style={{
+              textAlign: 'center',
+              fontFamily: 'DM Mono, monospace',
+              fontSize: 11, letterSpacing: '0.14em',
+              color: 'rgba(255,255,255,0.3)',
+              textTransform: 'uppercase',
+              marginBottom: 16,
+            }}>Light · Keyboard</div>
+
+            <IOSDevice dark={false} title="Notes" width={390} height={844} keyboard={true}>
+              <div style={{ padding: '0 16px' }}>
+                <IOSList dark={false}>
+                  <IOSListRow title="Today's training notes" detail="Now" icon="#FF9500" dark={false} />
+                  <IOSListRow title="Nutrition log"          detail="2m"  icon="#34C759" dark={false} />
+                  <IOSListRow title="Weekly check-in"        detail="1h"  icon="#007AFF" dark={false} isLast={true} />
+                </IOSList>
+              </div>
+            </IOSDevice>
+          </div>
+
+          {/* ── Pills showcase ── */}
+          <div>
+            <div style={{
+              textAlign: 'center',
+              fontFamily: 'DM Mono, monospace',
+              fontSize: 11, letterSpacing: '0.14em',
+              color: 'rgba(255,255,255,0.3)',
+              textTransform: 'uppercase',
+              marginBottom: 16,
+            }}>Glass Pills</div>
+
+            {/* dark pills on dark bg */}
+            <div style={{
+              background: '#1a1a1e',
+              borderRadius: 24,
+              padding: 24,
+              display: 'flex', gap: 12, flexWrap: 'wrap',
+              justifyContent: 'center', maxWidth: 300,
+            }}>
+              {['Back', 'Share', '···', 'Done'].map(label => (
+                <IOSGlassPill key={label} dark={true} style={{ padding: '0 18px' }}>
+                  <span style={{
+                    fontFamily: '-apple-system, system-ui',
+                    fontSize: 15, fontWeight: 600,
+                    color: '#fff',
+                  }}>{label}</span>
+                </IOSGlassPill>
+              ))}
+            </div>
+
+            <div style={{ height: 16 }} />
+
+            {/* light pills on light bg */}
+            <div style={{
+              background: '#F2F2F7',
+              borderRadius: 24,
+              padding: 24,
+              display: 'flex', gap: 12, flexWrap: 'wrap',
+              justifyContent: 'center', maxWidth: 300,
+            }}>
+              {['Back', 'Share', '···', 'Done'].map(label => (
+                <IOSGlassPill key={label} dark={false} style={{ padding: '0 18px' }}>
+                  <span style={{
+                    fontFamily: '-apple-system, system-ui',
+                    fontSize: 15, fontWeight: 600,
+                    color: '#000',
+                  }}>{label}</span>
+                </IOSGlassPill>
+              ))}
+            </div>
+          </div>
+
+        </div>
+      );
+    }
+
+    ReactDOM.createRoot(document.getElementById('root')).render(<Demo />);
+  </script>
+
+</body>
+</html>

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,11 @@
     Content-Security-Policy = "default-src 'self'; style-src 'self'; font-src 'self'; img-src 'self' data:; script-src 'self' 'unsafe-inline'; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
 
 [[headers]]
+  for = "/ios-demo.html"
+  [headers.values]
+    Content-Security-Policy = "default-src 'self'; style-src 'self' https://fonts.googleapis.com 'unsafe-inline'; font-src 'self' https://fonts.gstatic.com; img-src 'self' data:; script-src 'self' 'unsafe-inline' 'unsafe-eval' https://unpkg.com; connect-src 'self' https://unpkg.com; frame-ancestors 'none'; base-uri 'self'; form-action 'self'"
+
+[[headers]]
   for = "/assets/*"
   [headers.values]
     Cache-Control = "public, max-age=31536000, immutable"


### PR DESCRIPTION
## Summary

- Adds `components/iOS.jsx` — a zero-dependency JSX component library implementing the iOS 26 (Liquid Glass) UI kit: `IOSDevice`, `IOSStatusBar`, `IOSNavBar`, `IOSGlassPill`, `IOSList`, `IOSListRow`, `IOSKeyboard`. All components register on `window` so they work in no-build CDN contexts.
- Adds `ios-demo.html` — a standalone demo page (React 18 + Babel CDN, no build step) that renders two PKFIT-branded device mockups (dark Blueprint home screen + light keyboard demo) and a glass pills showcase.

## Test plan

- [ ] Open `ios-demo.html` directly in a browser (or via Netlify preview)
- [ ] Verify dark device renders: Dynamic Island, status bar, nav bar with glass pills, grouped lists, phase cards, gold CTA button, home indicator
- [ ] Verify light device renders: same chrome + keyboard with liquid glass background
- [ ] Verify glass pills section renders both dark and light variants
- [ ] Confirm `backdropFilter` blur is visible in a Chromium or Safari browser

https://claude.ai/code/session_01BsGr6y1tZfyishFa2CU2AK

---
_Generated by [Claude Code](https://claude.ai/code/session_01BsGr6y1tZfyishFa2CU2AK)_