### PR TITLE
Orchestration scaffold: PR template + CI smoke test

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,28 @@
+## What changed
+
+<!-- One sentence — what the PR ships. Mechanism-first, no hype. -->
+
+## Why
+
+<!-- The rule, the bug, the user need. Trace to canon if relevant (ATLAS, PACT). -->
+
+## Acceptance criteria
+
+- [ ] Build passes (`npm run build`)
+- [ ] No console errors on a fresh page load
+- [ ] Smoke-test command in this PR ran clean (paste output below)
+- [ ] No untracked secrets committed
+- [ ] BUILT ON AXIOM credit intact on user-facing surfaces
+- [ ] Linked to GitHub Issue #__ (closes #__)
+
+## Smoke-test output
+
+<!-- Paste the exact `curl` or test command + output that proves it works. -->
+
+## Screenshots / diff highlights
+
+<!-- One image or a 5-line diff snippet of the most consequential change. -->
+
+## Reviewer note
+
+<!-- Anything the reviewer (Percy) needs to know — gotchas, follow-ups, future agent guidance. -->

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,24 +1,34 @@
 name: CI
 
+# Smoke test: triggers on push and pull_request to any branch.
+# Target runtime: ~3 min. Steps deliberately minimal — fast feedback only.
+# Tests placeholder: re-enable when Vitest lands (see issue: test coverage).
+
 on:
   push:
-    branches: [main]
+    branches: ['**']
   pull_request:
-    branches: [main]
+    branches: ['**']
 
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
           cache: 'npm'
+
       - run: npm ci --no-audit --no-fund
-      - run: npm run lint
+
       - run: npm run build
         env:
+          # Vite needs these defined at build time. Real values live in Netlify env.
           VITE_SUPABASE_URL: https://placeholder.supabase.co
           VITE_SUPABASE_ANON_KEY: placeholder
           VITE_STRIPE_PUBLISHABLE_KEY: pk_test_placeholder
+
+      # Placeholder for `npm test` once Vitest is wired up.
+      # - run: npm test


### PR DESCRIPTION
Lays the harness for the multi-agent pkfit-app build.

## What changed

- `.github/PULL_REQUEST_TEMPLATE.md` — every PR now has the same structured shape (what / why / acceptance / smoke-test output / reviewer note).
- `.github/workflows/ci.yml` — node 20 + `npm ci` + `npm run build` on every push and PR (any branch). Test step is left commented as a placeholder for when Vitest lands (#16).

## Why

Foundation for parallel feature work. Every agent's PR runs through the same gate (build passes, smoke test, reviewer-friendly diff). Catches the bugs we kept hitting on intake/checkin (apostrophe syntax errors, etc.) before they ship.

## Linked issues — the queue this scaffold supports

- #13 Trainerize CSV/JSON importer (high)
- #14 PWA install + Web Push (high)
- #15 Exercise demo video library (medium)
- #16 Test coverage Vitest (high)
- #17 Shared UI component library (medium)
- #18 /api/health + post-deploy smoke (medium)
- #19 Apify scraper for Trainerize export (high)

## Adjustments from the spec

- Existing `ci.yml` on `app-main` triggered only on `main` branch and ran `npm run lint`. Replaced with the spec workflow (any branch, build only). Lint can come back when it's enforcing rules we actually want to block on; for now, build is the smoke test.
- Kept Vite env placeholders (`VITE_SUPABASE_URL`, `VITE_SUPABASE_ANON_KEY`, `VITE_STRIPE_PUBLISHABLE_KEY`) in the build step so CI passes without Netlify secrets. Real values live in Netlify env.
- Worktree at `/Users/percystewart/dev/PKFIT-orchestration-scaffold` keeps the `main` checkout (which was diverged with untracked superpowers files) untouched.

## Acceptance

- [x] Branch created off `app-main` (not `main`)
- [x] CI workflow triggers on this PR
- [ ] Build passes (waiting on CI run)
- [ ] Reviewer (Percy) approves merge to `app-main`
- [ ] Do **not** auto-merge — Percy reviews and merges himself
