### PR TITLE
feat(import): Trainerize → pkfit-app importer (#13)

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,81 @@ Public: `/`, `/login`, `/signup`, `/onboarding`, `/splash`
 Client: `/dashboard`, `/workouts`, `/workouts/builder`, `/workouts/generator`, `/meals`, `/meals/generator`, `/habits`, `/calendar`, `/reviews`, `/reviews/:id`, `/inbox`, `/community`, `/assistant`, `/billing`, `/profile`
 Coach: `/coach`, `/coach/inbox`, `/coach/clients`, `/coach/clients/:id`, `/coach/programs`, `/coach/revenue`, `/coach/announcements`
 
+## Migrating a client from Trainerize
+
+The importer ingests a Trainerize export (JSON) and writes the client's history into Supabase. Coach-auth only. Idempotent — re-running with the same payload skips already-imported rows.
+
+**Endpoint:** `POST /.netlify/functions/trainerize-import`
+
+**Auth:** Bearer token of a user whose `profiles.role = 'coach'`. The authed coach's UUID is also used as `author_id` for any messages with `direction: "from_coach"` in the export.
+
+**Request body:**
+
+```json
+{
+  "trainerize_export":   { ... see docs/trainerize-import-contract.md ... },
+  "trainerize_client_id": "tz_client_847211",
+  "dry_run":              false
+}
+```
+
+`trainerize_client_id` must equal `trainerize_export.client.trainerize_id` — the importer rejects payload-swap mistakes during a bulk migration.
+
+**Response shape:**
+
+```json
+{
+  "status":             "ok" | "partial" | "failed",
+  "client_id_supabase": "uuid",
+  "imported": { "programs": N, "sessions": N, "checkins": N,
+                "meals": N, "meal_adherence": N, "photos": N, "messages": N },
+  "skipped":  { ...per-section, with reasons },
+  "warnings": [ "..." ],
+  "dry_run":            false
+}
+```
+
+`status: "partial"` means at least one row was skipped for a reason other than already-imported (e.g., a meal-adherence tick referenced a meal that doesn't exist in the export). The skipped block tells you exactly what didn't land and why.
+
+**End-to-end example:**
+
+```bash
+TOKEN=$(supabase login token)   # or your existing coach JWT
+
+curl -X POST https://<site>/.netlify/functions/trainerize-import \
+  -H "Authorization: Bearer $TOKEN" \
+  -H "Content-Type: application/json" \
+  --data @tests/fixtures/trainerize-sample.json
+```
+
+**Dry-run first.** Set `"dry_run": true` to walk the entire payload through the mappers and dedup logic without writing to Supabase or Storage. The response shows what *would* have happened.
+
+```bash
+jq '. + {dry_run: true}' tests/fixtures/trainerize-sample.json \
+  | curl -X POST https://<site>/.netlify/functions/trainerize-import \
+      -H "Authorization: Bearer $TOKEN" \
+      -H "Content-Type: application/json" --data @-
+```
+
+**Local smoke (no Supabase needed):** runs the orchestrator against an in-memory fake admin and asserts idempotency.
+
+```bash
+node scripts/smoke-trainerize-import.js
+# → "SMOKE OK" if every assertion passes
+```
+
+**Companion issue:** the input JSON contract is consumed by Issue #19 (Apify Trainerize scraper). The full schema lives at `docs/trainerize-import-contract.md`; the canonical example is `tests/fixtures/trainerize-sample.json`. When the scraper lands, its output must validate against `_schema_version: "1.0.0"`.
+
+**Idempotency mechanics.** The schema has no `trainerize_*_id` columns, so the importer dedups via:
+
+- `profiles`: email is the natural key (`auth.users.email`).
+- `programs`, `workout_sessions`, `meals`: a `_meta.trainerize_id` marker is embedded inside the existing `jsonb` column (`exercises` / `items`) and matched on re-run.
+- `check_ins`: natural key `(client_id, date)` — Trainerize allows one weigh-in per day.
+- `dm_messages`: content hash on `(thread_id, sent_at, content)`.
+- `progress_photos`: deterministic Storage path `<client_id>/checkin-<iso>-<trainerize_id>.<ext>` with upsert.
+
+These markers are non-invasive — no schema migration is required. A future migration could add explicit `external_id text unique` columns for cleaner audit; flagged in the import contract doc.
+
 ## License
 
 Proprietary. All rights reserved.

--- a/docs/trainerize-import-contract.md
+++ b/docs/trainerize-import-contract.md
@@ -1,0 +1,183 @@
+# Trainerize Import Contract (v1.0.0)
+
+> Schema for the JSON payload accepted by `POST /.netlify/functions/trainerize-import`.
+> This is the contract Issue #19 (Apify Trainerize scraper) must produce.
+> Reference fixture: `tests/fixtures/trainerize-sample.json`.
+
+## Top-level shape
+
+```json
+{
+  "_schema_version": "1.0.0",
+  "_source": "trainerize-export",
+  "_exported_at": "ISO-8601 UTC timestamp",
+  "client":            { ... },
+  "programs":          [ ... ],
+  "workout_sessions":  [ ... ],
+  "check_ins":         [ ... ],
+  "meals":             [ ... ],
+  "meal_adherence":    [ ... ],
+  "progress_photos":   [ ... ],
+  "messages":          [ ... ]
+}
+```
+
+Every section is optional. A minimal valid payload is `{ "_schema_version": "1.0.0", "client": { ... } }`.
+
+The HTTP body wraps this object as:
+
+```json
+{
+  "trainerize_export": { ... },
+  "trainerize_client_id": "tz_client_847211",
+  "dry_run": false
+}
+```
+
+`trainerize_client_id` is required and is matched against `trainerize_export.client.trainerize_id`. They must agree — this guards against payload-swap mistakes during a bulk migration. `dry_run: true` runs all mappers and dedup logic without writing to Supabase or Storage; the response shows what *would* have happened.
+
+## `client` (object)
+
+| Field                  | Required | Type    | Mapped to                                    |
+|------------------------|----------|---------|----------------------------------------------|
+| `trainerize_id`        | yes      | string  | embedded in `_meta` markers throughout       |
+| `email`                | yes      | string  | `auth.users.email` (natural key for dedup)   |
+| `name`                 | no       | string  | `profiles.name`                              |
+| `joined_at`            | no       | ISO     | `profiles.start_date` (date portion)         |
+| `plan_label`           | no       | string  | `profiles.plan` (free-text — not enforced)   |
+| `weight_unit`          | no       | "lbs" \| "kg" | `profiles.units` ('imperial' if 'lbs', else 'metric') |
+| `height_unit`          | no       | "in" \| "cm"  | informational only                            |
+| `starting_weight_kg`   | no       | number  | seeds first `check_ins` row if no check-ins  |
+| `starting_height_cm`   | no       | number  | informational only (no column today)         |
+
+**Idempotency:** if `auth.users` already has a row with this email, we use that user; we do not create a duplicate. If not, we call `admin.auth.admin.createUser` with `email_confirm: true` and the trigger creates the `profiles` row, which we then update.
+
+## `programs` (array of objects)
+
+| Field                  | Required | Mapped to                                    |
+|------------------------|----------|----------------------------------------------|
+| `trainerize_id`        | yes      | embedded in `programs.exercises._meta.trainerize_id` |
+| `week_number`          | no       | `programs.week_number` (default 1)           |
+| `title`                | no       | folded into `programs.schedule.title`        |
+| `status`               | no       | `programs.status` ('active' / 'archived' / 'draft') |
+| `schedule`             | no       | `programs.schedule` (jsonb)                  |
+| `exercises`            | yes      | wrapped: `{ _meta: { trainerize_id }, items: [...] }` and stored on `programs.exercises` |
+
+## `workout_sessions` (array of objects)
+
+| Field                     | Required | Mapped to                                    |
+|---------------------------|----------|----------------------------------------------|
+| `trainerize_id`           | yes      | embedded in `workout_sessions.exercises._meta.trainerize_id` |
+| `trainerize_program_id`   | no       | resolved to local `program_id` after programs import |
+| `performed_at`            | yes      | `workout_sessions.performed_at` (timestamptz) |
+| `duration_min`            | no       | `workout_sessions.duration_min`              |
+| `rpe_avg`                 | no       | `workout_sessions.rpe_avg`                   |
+| `notes`                   | no       | `workout_sessions.notes`                     |
+| `exercises`               | yes      | wrapped: `{ _meta: { trainerize_id }, items: [...] }` |
+
+## `check_ins` (array of objects)
+
+| Field             | Required | Mapped to                              |
+|-------------------|----------|----------------------------------------|
+| `trainerize_id`   | yes      | content-hash dedup key (no jsonb to embed in) |
+| `date`            | yes      | `check_ins.date`                       |
+| `weight_kg`       | no       | `check_ins.weight`                     |
+| `body_fat_pct`    | no       | `check_ins.body_fat`                   |
+| `notes`           | no       | `check_ins.notes`                      |
+
+**Dedup:** since `check_ins` has no jsonb column, we use natural key `(client_id, date)`. If a row already exists we skip + warn rather than overwrite.
+
+## `meals` (array of objects)
+
+| Field             | Required | Mapped to                              |
+|-------------------|----------|----------------------------------------|
+| `trainerize_id`   | yes      | embedded in `meals.items._meta.trainerize_id` |
+| `date`            | no       | `meals.date`                           |
+| `day`             | no       | `meals.day` ('mon', 'tue', …)          |
+| `meal_type`       | no       | `meals.meal_type`                      |
+| `items`           | yes      | wrapped jsonb with `_meta`             |
+| `macros`          | no       | `meals.macros`                         |
+
+## `meal_adherence` (array of objects)
+
+| Field                      | Required | Effect                                                    |
+|----------------------------|----------|-----------------------------------------------------------|
+| `trainerize_meal_id`       | yes      | matches `meals.items._meta.trainerize_id` already imported |
+| `eaten`                    | yes      | toggles `meals.eaten`                                      |
+| `eaten_at`                 | no       | `meals.eaten_at`                                           |
+
+**Skip-and-warn:** if `trainerize_meal_id` does not match a previously imported meal, the adherence row is skipped and added to `warnings`. We do not invent a meal row — that would be data fabrication.
+
+## `progress_photos` (array of objects)
+
+| Field            | Required | Effect                                                   |
+|------------------|----------|----------------------------------------------------------|
+| `trainerize_id`  | yes      | embedded in storage filename                             |
+| `checkin_date`   | yes      | matches a `check_ins` row by `(client_id, date)`         |
+| `captured_at`    | no       | informational (filename also embeds timestamp)           |
+| `mime_type`      | yes      | "image/jpeg" or "image/png"                              |
+| `data_base64`    | yes      | base64-encoded image bytes                               |
+
+**Storage:** uploaded to existing `baseline-photos` bucket at path `<client_id>/checkin-<iso-timestamp>-<trainerize_id>.<ext>`. The corresponding `check_ins.photo_path` is set to that path. We reuse the existing bucket because there is no `checkin_photos` bucket on `app-main` today (the schema folds check-in and baseline photos into one bucket per migration `0008_checkin_photos.sql`).
+
+**Idempotency:** Storage upload uses upsert with the deterministic path; re-uploading the same file is a no-op.
+
+## `messages` (array of objects)
+
+| Field            | Required | Effect                                                   |
+|------------------|----------|----------------------------------------------------------|
+| `trainerize_id`  | yes      | content-hash dedup key                                   |
+| `sent_at`        | yes      | `dm_messages.created_at` (preserved from source)         |
+| `direction`      | yes      | `"from_client"` → `author_id = client.id`; `"from_coach"` → `author_id = <authed-coach-id>` |
+| `content`        | yes      | `dm_messages.content`                                    |
+
+A single `dm_threads` row is upserted per client (unique on `client_id`). Messages are inserted into that thread.
+
+**Dedup:** content-hash on `(thread_id, created_at_iso, content)`. If a row with the same hash already exists, skip.
+
+## Response shape
+
+```json
+{
+  "status": "ok" | "partial" | "failed",
+  "client_id_supabase": "uuid",
+  "imported": {
+    "programs": 2,
+    "sessions": 2,
+    "checkins": 2,
+    "meals": 2,
+    "meal_adherence": 2,
+    "photos": 1,
+    "messages": 3
+  },
+  "skipped": {
+    "programs":       [{ "trainerize_id": "...", "reason": "already imported (matching _meta.trainerize_id)" }],
+    "sessions":       [...],
+    "checkins":       [...],
+    "meals":          [...],
+    "meal_adherence": [{ "trainerize_meal_id": "tz_meal_77412_orphan", "reason": "no matching meal in import or in db" }],
+    "photos":         [...],
+    "messages":       [...]
+  },
+  "warnings": [
+    "client.starting_height_cm: no column on profiles — value retained in raw payload only"
+  ]
+}
+```
+
+`status`:
+- `ok` — every section either imported or fully skipped as already-present.
+- `partial` — at least one row landed in `skipped` for a reason other than already-imported (e.g., missing required field, orphan reference).
+- `failed` — the import aborted before completing client setup, or any database error fired. Body includes `error`.
+
+## Schema gaps flagged for future migration
+
+These are the points where Trainerize concepts do not map cleanly to the current schema. Documented for the reviewer; no migration is shipped in this PR.
+
+1. **`profiles` lacks `trainerize_client_id`.** We use email as the natural key today. A future migration could add `profiles.trainerize_client_id text unique` for explicit dedup and audit.
+2. **`baseline-photos` bucket holds both baseline and check-in photos.** Issue #13 referenced a `checkin_photos` bucket; one does not exist. A future migration could split them or rename the bucket.
+3. **No per-row `external_id` columns** on `programs`, `workout_sessions`, `check_ins`, `meals`, `dm_messages`. We embed in jsonb where possible and use content hashes elsewhere. Adding explicit `external_id text` columns with unique indexes would simplify dedup and audit.
+
+## Versioning
+
+Bump `_schema_version` on any breaking change. The importer reads this and rejects payloads with major-version mismatches.

--- a/netlify/functions/_shared/trainerize-mappers.js
+++ b/netlify/functions/_shared/trainerize-mappers.js
@@ -1,0 +1,208 @@
+// Pure mapping functions for the Trainerize → PKFIT importer. No Supabase
+// dependencies — everything here is deterministic data transformation, easy to
+// unit test in isolation. The function entry point composes these mappers and
+// applies the database side effects.
+//
+// Schema gaps:
+//   • profiles has no trainerize_client_id column (email is the natural key).
+//   • programs / workout_sessions / meals have no external_id column — we
+//     embed _meta.trainerize_id inside their jsonb columns instead.
+//   • check_ins / dm_messages have no jsonb — content hashes guard dedup.
+//   • Issue #13 referenced a checkin_photos bucket; the live bucket is
+//     baseline-photos (per migration 0008). We use that and flag the gap.
+//
+// See docs/trainerize-import-contract.md for the full payload shape.
+
+import { createHash } from 'node:crypto';
+
+export const SUPPORTED_SCHEMA_MAJOR = 1;
+export const PHOTOS_BUCKET = 'baseline-photos';
+
+// ─── helpers ────────────────────────────────────────────────────────────
+
+export function parseSchemaVersion(v) {
+  if (typeof v !== 'string') return null;
+  const m = v.match(/^(\d+)\.(\d+)\.(\d+)$/);
+  if (!m) return null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]) };
+}
+
+export function isSchemaCompatible(v) {
+  const parsed = parseSchemaVersion(v);
+  return Boolean(parsed && parsed.major === SUPPORTED_SCHEMA_MAJOR);
+}
+
+// Stable SHA-256 hex of a string. Used as a content key when we don't have a
+// jsonb column to embed the trainerize_id into.
+export function contentHash(...parts) {
+  const h = createHash('sha256');
+  for (const p of parts) h.update(String(p ?? ''));
+  return h.digest('hex');
+}
+
+function isoDateOnly(iso) {
+  if (!iso) return null;
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return null;
+  return d.toISOString().slice(0, 10);
+}
+
+// ─── client / profile ───────────────────────────────────────────────────
+
+export function mapProfileFields(client) {
+  const out = {};
+  if (client.name) out.name = client.name;
+  if (client.email) out.email = client.email;
+  if (client.plan_label) out.plan = client.plan_label;
+  const start = isoDateOnly(client.joined_at);
+  if (start) out.start_date = start;
+  if (client.weight_unit === 'lbs') out.units = 'imperial';
+  else if (client.weight_unit === 'kg') out.units = 'metric';
+  return out;
+}
+
+// ─── programs ──────────────────────────────────────────────────────────
+
+export function mapProgramRow(client_id, program) {
+  const status = program.status === 'active' || program.status === 'archived' || program.status === 'draft'
+    ? program.status
+    : 'archived';
+  const schedule = {
+    ...(program.schedule ?? {}),
+    title: program.title ?? program.schedule?.title,
+  };
+  return {
+    client_id,
+    week_number: Number.isFinite(program.week_number) ? program.week_number : 1,
+    schedule,
+    exercises: {
+      _meta: { trainerize_id: program.trainerize_id, source: 'trainerize' },
+      items: Array.isArray(program.exercises) ? program.exercises : [],
+    },
+    status,
+  };
+}
+
+// ─── workout sessions ──────────────────────────────────────────────────
+
+export function mapSessionRow(client_id, session, programIdMap) {
+  const localProgramId = session.trainerize_program_id
+    ? programIdMap.get(session.trainerize_program_id) ?? null
+    : null;
+  return {
+    client_id,
+    program_id: localProgramId,
+    performed_at: session.performed_at,
+    duration_min: Number.isFinite(session.duration_min) ? session.duration_min : null,
+    rpe_avg: Number.isFinite(session.rpe_avg) ? session.rpe_avg : null,
+    notes: session.notes ?? null,
+    exercises: {
+      _meta: { trainerize_id: session.trainerize_id, source: 'trainerize' },
+      items: Array.isArray(session.exercises) ? session.exercises : [],
+    },
+  };
+}
+
+// ─── check-ins ─────────────────────────────────────────────────────────
+
+export function mapCheckInRow(client_id, checkin) {
+  return {
+    client_id,
+    date: checkin.date,
+    weight: Number.isFinite(checkin.weight_kg) ? checkin.weight_kg : null,
+    body_fat: Number.isFinite(checkin.body_fat_pct) ? checkin.body_fat_pct : null,
+    notes: checkin.notes ?? null,
+  };
+}
+
+export function checkInDedupKey(client_id, checkin) {
+  // No jsonb column — natural key (client_id, date). Two rows for the same
+  // day collapse to one (Trainerize itself only allows one weigh-in per day).
+  return contentHash(client_id, checkin.date);
+}
+
+// ─── meals ─────────────────────────────────────────────────────────────
+
+export function mapMealRow(client_id, meal) {
+  return {
+    client_id,
+    date: meal.date ?? null,
+    day: meal.day ?? null,
+    meal_type: meal.meal_type ?? null,
+    items: {
+      _meta: { trainerize_id: meal.trainerize_id, source: 'trainerize' },
+      items: Array.isArray(meal.items) ? meal.items : [],
+    },
+    macros: meal.macros ?? {},
+  };
+}
+
+// Adherence resolves the trainerize_meal_id against meals already imported.
+// Returns { ok: true, update } or { ok: false, reason }.
+export function resolveAdherence(adherence, mealIdMap) {
+  const tzId = adherence.trainerize_meal_id;
+  const supabaseMealId = mealIdMap.get(tzId);
+  if (!supabaseMealId) {
+    return { ok: false, reason: 'no matching meal in import or in db' };
+  }
+  return {
+    ok: true,
+    supabase_meal_id: supabaseMealId,
+    update: {
+      eaten: Boolean(adherence.eaten),
+      eaten_at: adherence.eaten_at ?? null,
+    },
+  };
+}
+
+// ─── progress photos ───────────────────────────────────────────────────
+
+export function buildPhotoPath(client_id, photo) {
+  const ext = photo.mime_type === 'image/png' ? 'png'
+    : photo.mime_type === 'image/jpeg' ? 'jpg'
+    : 'bin';
+  const ts = photo.captured_at ?? photo.checkin_date ?? new Date().toISOString();
+  const tsClean = String(ts).replace(/[:]/g, '-');
+  return `${client_id}/checkin-${tsClean}-${photo.trainerize_id}.${ext}`;
+}
+
+export function decodePhotoBase64(b64) {
+  if (typeof b64 !== 'string' || b64.length === 0) {
+    return { ok: false, reason: 'empty data_base64' };
+  }
+  try {
+    const buf = Buffer.from(b64, 'base64');
+    if (buf.length === 0) return { ok: false, reason: 'invalid base64' };
+    return { ok: true, buffer: buf };
+  } catch {
+    return { ok: false, reason: 'invalid base64' };
+  }
+}
+
+// ─── messages ──────────────────────────────────────────────────────────
+
+export function mapMessageRow(thread_id, client_id, coach_id, msg) {
+  let author_id = null;
+  if (msg.direction === 'from_client') author_id = client_id;
+  else if (msg.direction === 'from_coach') author_id = coach_id;
+  return {
+    thread_id,
+    author_id,
+    content: msg.content,
+    created_at: msg.sent_at,
+    // Imported history is read-by-everyone — nothing should pop as unread on day one.
+    read_by_client: true,
+    read_by_coach: true,
+  };
+}
+
+export function messageDedupKey(thread_id, msg) {
+  return contentHash(thread_id, msg.sent_at, msg.content);
+}
+
+// ─── extractors for embedded trainerize_ids ────────────────────────────
+
+export function extractTrainerizeIdFromJsonbWrap(wrap) {
+  if (!wrap || typeof wrap !== 'object') return null;
+  return wrap?._meta?.trainerize_id ?? null;
+}

--- a/netlify/functions/_shared/trainerize-mappers.test.js
+++ b/netlify/functions/_shared/trainerize-mappers.test.js
@@ -1,0 +1,257 @@
+// Pure-function tests for the Trainerize mappers. Vitest-compatible.
+//
+// pkfit-app does not have Vitest installed yet (Issue #16 will land it).
+// These tests are written against the standard Vitest API so they run as soon
+// as the framework arrives. Until then the file documents the expected
+// behaviour and protects future refactors.
+
+import { describe, it, expect } from 'vitest';
+import {
+  parseSchemaVersion,
+  isSchemaCompatible,
+  contentHash,
+  mapProfileFields,
+  mapProgramRow,
+  mapSessionRow,
+  mapCheckInRow,
+  checkInDedupKey,
+  mapMealRow,
+  resolveAdherence,
+  buildPhotoPath,
+  decodePhotoBase64,
+  mapMessageRow,
+  messageDedupKey,
+  extractTrainerizeIdFromJsonbWrap,
+  PHOTOS_BUCKET,
+  SUPPORTED_SCHEMA_MAJOR,
+} from './trainerize-mappers.js';
+
+describe('parseSchemaVersion / isSchemaCompatible', () => {
+  it('parses semver triples', () => {
+    expect(parseSchemaVersion('1.2.3')).toEqual({ major: 1, minor: 2, patch: 3 });
+  });
+
+  it('rejects non-semver', () => {
+    expect(parseSchemaVersion('1.2')).toBeNull();
+    expect(parseSchemaVersion('latest')).toBeNull();
+    expect(parseSchemaVersion(undefined)).toBeNull();
+  });
+
+  it('accepts current major, rejects others', () => {
+    expect(SUPPORTED_SCHEMA_MAJOR).toBe(1);
+    expect(isSchemaCompatible('1.0.0')).toBe(true);
+    expect(isSchemaCompatible('1.99.0')).toBe(true);
+    expect(isSchemaCompatible('2.0.0')).toBe(false);
+    expect(isSchemaCompatible('0.9.0')).toBe(false);
+  });
+});
+
+describe('contentHash', () => {
+  it('is deterministic and order-sensitive', () => {
+    expect(contentHash('a', 'b')).toBe(contentHash('a', 'b'));
+    expect(contentHash('a', 'b')).not.toBe(contentHash('b', 'a'));
+  });
+  it('treats null and undefined as empty string', () => {
+    expect(contentHash(null, undefined)).toBe(contentHash('', ''));
+  });
+});
+
+describe('mapProfileFields', () => {
+  it('maps the shipping fields, drops anything not on the schema', () => {
+    const out = mapProfileFields({
+      trainerize_id: 'tz_x',
+      email: 'a@b.test',
+      name: 'Alice',
+      joined_at: '2026-01-15T00:00:00Z',
+      plan_label: 'Performance Standard',
+      weight_unit: 'lbs',
+      starting_height_cm: 180,
+    });
+    expect(out).toEqual({
+      email: 'a@b.test',
+      name: 'Alice',
+      start_date: '2026-01-15',
+      plan: 'Performance Standard',
+      units: 'imperial',
+    });
+  });
+
+  it('falls back to metric when weight_unit is "kg"', () => {
+    expect(mapProfileFields({ weight_unit: 'kg' }).units).toBe('metric');
+  });
+
+  it('omits fields when the source key is absent', () => {
+    expect(mapProfileFields({ email: 'a@b.test' })).toEqual({ email: 'a@b.test' });
+  });
+});
+
+describe('mapProgramRow', () => {
+  it('embeds trainerize_id in exercises._meta', () => {
+    const row = mapProgramRow('client-uuid', {
+      trainerize_id: 'tz_program_1',
+      week_number: 2,
+      title: 'Week 2',
+      status: 'active',
+      schedule: { days: ['mon'] },
+      exercises: [{ name: 'Back Squat' }],
+    });
+    expect(row.exercises._meta).toEqual({ trainerize_id: 'tz_program_1', source: 'trainerize' });
+    expect(row.exercises.items).toEqual([{ name: 'Back Squat' }]);
+    expect(row.schedule.title).toBe('Week 2');
+    expect(row.client_id).toBe('client-uuid');
+    expect(row.status).toBe('active');
+    expect(row.week_number).toBe(2);
+  });
+
+  it('coerces unknown status to archived', () => {
+    expect(mapProgramRow('c', { trainerize_id: 'x', status: 'wat' }).status).toBe('archived');
+  });
+
+  it('defaults week_number to 1', () => {
+    expect(mapProgramRow('c', { trainerize_id: 'x' }).week_number).toBe(1);
+  });
+});
+
+describe('mapSessionRow', () => {
+  it('resolves trainerize_program_id via the program map', () => {
+    const map = new Map([['tz_program_1', 'supabase-program-uuid']]);
+    const row = mapSessionRow('client-uuid', {
+      trainerize_id: 'tz_session_1',
+      trainerize_program_id: 'tz_program_1',
+      performed_at: '2026-01-19T17:08:00Z',
+      duration_min: 62,
+      rpe_avg: 7.5,
+      notes: 'felt strong',
+      exercises: [{ name: 'Back Squat' }],
+    }, map);
+    expect(row.program_id).toBe('supabase-program-uuid');
+    expect(row.exercises._meta.trainerize_id).toBe('tz_session_1');
+  });
+
+  it('leaves program_id null when unmapped', () => {
+    const row = mapSessionRow('c', {
+      trainerize_id: 'tz_s',
+      trainerize_program_id: 'tz_unknown',
+      performed_at: '2026-01-19T17:08:00Z',
+      exercises: [],
+    }, new Map());
+    expect(row.program_id).toBeNull();
+  });
+});
+
+describe('mapCheckInRow / checkInDedupKey', () => {
+  it('maps weight_kg → weight and body_fat_pct → body_fat', () => {
+    const row = mapCheckInRow('c', { date: '2026-01-19', weight_kg: 85.7, body_fat_pct: 18.4, notes: 'ok' });
+    expect(row).toEqual({ client_id: 'c', date: '2026-01-19', weight: 85.7, body_fat: 18.4, notes: 'ok' });
+  });
+
+  it('produces a stable per-client-per-date dedup key', () => {
+    const a = checkInDedupKey('c', { date: '2026-01-19' });
+    const b = checkInDedupKey('c', { date: '2026-01-19' });
+    expect(a).toBe(b);
+    expect(checkInDedupKey('c', { date: '2026-01-19' })).not.toBe(checkInDedupKey('c', { date: '2026-01-26' }));
+  });
+});
+
+describe('mapMealRow + resolveAdherence', () => {
+  it('wraps items with _meta and preserves macros', () => {
+    const row = mapMealRow('c', {
+      trainerize_id: 'tz_meal_1',
+      date: '2026-01-19',
+      meal_type: 'lunch',
+      items: [{ name: 'Rice' }],
+      macros: { kcal: 600 },
+    });
+    expect(row.items._meta.trainerize_id).toBe('tz_meal_1');
+    expect(row.items.items).toEqual([{ name: 'Rice' }]);
+    expect(row.macros).toEqual({ kcal: 600 });
+  });
+
+  it('resolveAdherence returns ok for matched meal', () => {
+    const map = new Map([['tz_meal_1', 'supabase-meal-uuid']]);
+    const r = resolveAdherence({ trainerize_meal_id: 'tz_meal_1', eaten: true, eaten_at: '2026-01-19T13:05:00Z' }, map);
+    expect(r.ok).toBe(true);
+    expect(r.supabase_meal_id).toBe('supabase-meal-uuid');
+    expect(r.update.eaten).toBe(true);
+    expect(r.update.eaten_at).toBe('2026-01-19T13:05:00Z');
+  });
+
+  it('resolveAdherence returns reason for orphan trainerize_meal_id', () => {
+    const r = resolveAdherence({ trainerize_meal_id: 'tz_orphan' }, new Map());
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/no matching meal/);
+  });
+});
+
+describe('buildPhotoPath / decodePhotoBase64', () => {
+  it('builds a deterministic path keyed on client and trainerize_id', () => {
+    const p = buildPhotoPath('client-uuid', {
+      trainerize_id: 'tz_photo_22001',
+      mime_type: 'image/jpeg',
+      captured_at: '2026-01-19T07:30:00Z',
+    });
+    expect(p).toBe('client-uuid/checkin-2026-01-19T07-30-00.000Z-tz_photo_22001.jpg');
+    // Path is deterministic on the same input — that's the upsert key.
+    expect(buildPhotoPath('client-uuid', {
+      trainerize_id: 'tz_photo_22001',
+      mime_type: 'image/jpeg',
+      captured_at: '2026-01-19T07:30:00Z',
+    })).toBe(p);
+  });
+
+  it('handles png mime', () => {
+    expect(buildPhotoPath('c', { trainerize_id: 'tz_p', mime_type: 'image/png', captured_at: '2026-01-19T07:30:00Z' })).toMatch(/\.png$/);
+  });
+
+  it('decodes a tiny base64 PNG into a buffer', () => {
+    const r = decodePhotoBase64('iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII=');
+    expect(r.ok).toBe(true);
+    expect(r.buffer.length).toBeGreaterThan(0);
+  });
+
+  it('rejects empty or non-base64 input', () => {
+    expect(decodePhotoBase64('').ok).toBe(false);
+    expect(decodePhotoBase64(null).ok).toBe(false);
+  });
+});
+
+describe('mapMessageRow / messageDedupKey', () => {
+  it('routes from_client to client author, from_coach to coach author', () => {
+    const inbound = mapMessageRow('thread', 'c', 'coach', {
+      direction: 'from_client', content: 'hi', sent_at: '2026-01-15T10:00:00Z',
+    });
+    expect(inbound.author_id).toBe('c');
+    expect(inbound.read_by_client).toBe(true);
+    expect(inbound.read_by_coach).toBe(true);
+
+    const outbound = mapMessageRow('thread', 'c', 'coach', {
+      direction: 'from_coach', content: 'hello', sent_at: '2026-01-15T10:00:00Z',
+    });
+    expect(outbound.author_id).toBe('coach');
+  });
+
+  it('content hash is stable across runs and changes with content or timestamp', () => {
+    const m = { content: 'hi', sent_at: '2026-01-15T10:00:00Z' };
+    expect(messageDedupKey('t1', m)).toBe(messageDedupKey('t1', m));
+    expect(messageDedupKey('t1', m)).not.toBe(messageDedupKey('t1', { ...m, content: 'hi2' }));
+    expect(messageDedupKey('t1', m)).not.toBe(messageDedupKey('t1', { ...m, sent_at: '2026-01-15T10:00:01Z' }));
+    expect(messageDedupKey('t1', m)).not.toBe(messageDedupKey('t2', m));
+  });
+});
+
+describe('extractTrainerizeIdFromJsonbWrap', () => {
+  it('reads from _meta.trainerize_id', () => {
+    expect(extractTrainerizeIdFromJsonbWrap({ _meta: { trainerize_id: 'tz_x' }, items: [] })).toBe('tz_x');
+  });
+  it('returns null on missing or malformed wrappers', () => {
+    expect(extractTrainerizeIdFromJsonbWrap(null)).toBeNull();
+    expect(extractTrainerizeIdFromJsonbWrap({})).toBeNull();
+    expect(extractTrainerizeIdFromJsonbWrap([{ legacy: true }])).toBeNull();
+  });
+});
+
+describe('PHOTOS_BUCKET', () => {
+  it('points at the existing baseline-photos bucket per migration 0008', () => {
+    expect(PHOTOS_BUCKET).toBe('baseline-photos');
+  });
+});

--- a/netlify/functions/trainerize-import.js
+++ b/netlify/functions/trainerize-import.js
@@ -1,0 +1,520 @@
+// POST /.netlify/functions/trainerize-import
+//
+// Ingests a Trainerize export (JSON) and writes to Supabase. Coach-auth only.
+// Idempotent — re-running with the same payload skips already-imported rows.
+//
+// Companion: Issue #19 (Apify scraper) produces the JSON in the schema
+// documented at docs/trainerize-import-contract.md and exemplified at
+// tests/fixtures/trainerize-sample.json.
+//
+// Supports an internal seam for testing: pass a custom { admin, anon } pair
+// into runImport() to substitute mock clients in unit tests without touching
+// real Supabase. The HTTP handler always uses the production clients.
+
+// Auth helpers and the production Supabase admin client are imported lazily
+// inside the HTTP handler. That keeps `runImport` — the testable orchestrator
+// surface — free of any Supabase module dependency, so unit tests can run
+// against a fake admin without installing @supabase/supabase-js into the test
+// environment.
+import {
+  isSchemaCompatible,
+  mapProfileFields,
+  mapProgramRow,
+  mapSessionRow,
+  mapCheckInRow,
+  checkInDedupKey,
+  mapMealRow,
+  resolveAdherence,
+  buildPhotoPath,
+  decodePhotoBase64,
+  mapMessageRow,
+  messageDedupKey,
+  extractTrainerizeIdFromJsonbWrap,
+  PHOTOS_BUCKET,
+} from './_shared/trainerize-mappers.js';
+
+export const handler = async (event) => {
+  const { jsonResponse, errorResponse, requireUser } = await import('./_shared/auth.js');
+  const { getAdminClient } = await import('./_shared/supabase-admin.js');
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' });
+  try {
+    const { user, role } = await requireUser(event);
+    if (role !== 'coach') return jsonResponse(403, { error: 'Coach only' });
+
+    const body = JSON.parse(event.body || '{}');
+    const exp = body.trainerize_export;
+    const tzClientId = body.trainerize_client_id;
+    const dryRun = Boolean(body.dry_run);
+
+    if (!exp) return jsonResponse(400, { error: 'trainerize_export required' });
+    if (!tzClientId) return jsonResponse(400, { error: 'trainerize_client_id required' });
+    if (!isSchemaCompatible(exp._schema_version)) {
+      return jsonResponse(400, {
+        error: `Unsupported _schema_version "${exp._schema_version}". Supported major: 1.x.x.`,
+      });
+    }
+    if (!exp.client?.email) {
+      return jsonResponse(400, { error: 'client.email required' });
+    }
+    if (exp.client.trainerize_id !== tzClientId) {
+      return jsonResponse(400, {
+        error: `trainerize_client_id "${tzClientId}" does not match client.trainerize_id "${exp.client.trainerize_id}"`,
+      });
+    }
+
+    const result = await runImport({
+      admin: getAdminClient(),
+      coachId: user.id,
+      payload: exp,
+      dryRun,
+    });
+
+    return jsonResponse(200, result);
+  } catch (e) {
+    return errorResponse(e);
+  }
+};
+
+// ─── core ──────────────────────────────────────────────────────────────
+
+export async function runImport({ admin, coachId, payload, dryRun }) {
+  const warnings = [];
+  const skipped = {
+    programs: [], sessions: [], checkins: [], meals: [],
+    meal_adherence: [], photos: [], messages: [],
+  };
+  const imported = {
+    programs: 0, sessions: 0, checkins: 0, meals: 0,
+    meal_adherence: 0, photos: 0, messages: 0,
+  };
+
+  // 1) Resolve / create the client profile.
+  const clientId = await ensureClient({ admin, client: payload.client, dryRun, warnings });
+
+  // Track informational fields that have no home.
+  if (payload.client.starting_height_cm != null) {
+    warnings.push('client.starting_height_cm: no column on profiles — value retained in raw payload only');
+  }
+  if (payload.client.starting_weight_kg != null && !(payload.check_ins?.length)) {
+    warnings.push('client.starting_weight_kg: no check_ins in payload to seed; value not persisted');
+  }
+
+  // 2) Programs. Map of trainerize_program_id → supabase program_id.
+  const programIdMap = await importPrograms({
+    admin, clientId, programs: payload.programs ?? [],
+    dryRun, imported, skipped,
+  });
+
+  // 3) Workout sessions, joined to programIdMap.
+  await importSessions({
+    admin, clientId, sessions: payload.workout_sessions ?? [],
+    programIdMap, dryRun, imported, skipped,
+  });
+
+  // 4) Check-ins.
+  await importCheckIns({
+    admin, clientId, checkins: payload.check_ins ?? [],
+    dryRun, imported, skipped,
+  });
+
+  // 5) Meals + adherence (adherence reads the meal map written here).
+  const mealIdMap = await importMeals({
+    admin, clientId, meals: payload.meals ?? [],
+    dryRun, imported, skipped,
+  });
+  await applyMealAdherence({
+    admin, adherence: payload.meal_adherence ?? [],
+    mealIdMap, dryRun, imported, skipped,
+  });
+
+  // 6) Progress photos. Storage upload + check_ins.photo_path update.
+  await importPhotos({
+    admin, clientId, photos: payload.progress_photos ?? [],
+    dryRun, imported, skipped, warnings,
+  });
+
+  // 7) DM messages.
+  await importMessages({
+    admin, clientId, coachId, messages: payload.messages ?? [],
+    dryRun, imported, skipped,
+  });
+
+  const anySkipsOtherThanAlreadyImported = Object.values(skipped).some((arr) =>
+    arr.some((s) => s.reason && !s.reason.startsWith('already imported')),
+  );
+  const status = anySkipsOtherThanAlreadyImported ? 'partial' : 'ok';
+
+  return {
+    status,
+    client_id_supabase: clientId,
+    imported,
+    skipped,
+    warnings,
+    dry_run: dryRun,
+  };
+}
+
+// ─── client / profile ──────────────────────────────────────────────────
+
+async function ensureClient({ admin, client, dryRun, warnings }) {
+  // Look up by email first via profiles. Fast and uses our own table.
+  const { data: existing } = await admin
+    .from('profiles')
+    .select('id')
+    .eq('email', client.email)
+    .maybeSingle();
+
+  let userId = existing?.id ?? null;
+
+  if (!userId) {
+    if (dryRun) {
+      // Synthetic UUID for dry-run reporting only — never written.
+      userId = '00000000-0000-0000-0000-000000000000';
+    } else {
+      const { data: created, error } = await admin.auth.admin.createUser({
+        email: client.email,
+        email_confirm: true,
+        user_metadata: { name: client.name ?? '', source: 'trainerize-import' },
+      });
+      if (error) {
+        const wrapped = new Error(`auth.admin.createUser failed: ${error.message}`);
+        wrapped.statusCode = 500;
+        throw wrapped;
+      }
+      userId = created.user.id;
+    }
+  }
+
+  const updates = mapProfileFields(client);
+  if (!dryRun && Object.keys(updates).length > 0) {
+    const { error } = await admin.from('profiles').update(updates).eq('id', userId);
+    if (error) {
+      // Profile update failure is non-fatal — surface as warning, the auth user
+      // and the trigger-created profile row already exist.
+      warnings.push(`profile update failed: ${error.message}`);
+    }
+  }
+  return userId;
+}
+
+// ─── programs ──────────────────────────────────────────────────────────
+
+async function importPrograms({ admin, clientId, programs, dryRun, imported, skipped }) {
+  const idMap = new Map();
+  if (programs.length === 0) return idMap;
+
+  // Pre-fetch existing programs for this client and index by embedded trainerize_id.
+  const existingByTzId = await fetchExistingByTzId(admin, 'programs', clientId, 'exercises');
+
+  for (const p of programs) {
+    if (!p.trainerize_id) {
+      skipped.programs.push({ reason: 'missing trainerize_id' });
+      continue;
+    }
+    const hit = existingByTzId.get(p.trainerize_id);
+    if (hit) {
+      idMap.set(p.trainerize_id, hit.id);
+      skipped.programs.push({ trainerize_id: p.trainerize_id, reason: 'already imported (matching _meta.trainerize_id)' });
+      continue;
+    }
+    const row = mapProgramRow(clientId, p);
+    if (dryRun) {
+      idMap.set(p.trainerize_id, `dry-run-program-${imported.programs}`);
+      imported.programs += 1;
+      continue;
+    }
+    const { data, error } = await admin.from('programs').insert(row).select('id').single();
+    if (error) {
+      skipped.programs.push({ trainerize_id: p.trainerize_id, reason: `db error: ${error.message}` });
+      continue;
+    }
+    idMap.set(p.trainerize_id, data.id);
+    imported.programs += 1;
+  }
+  return idMap;
+}
+
+// ─── sessions ──────────────────────────────────────────────────────────
+
+async function importSessions({ admin, clientId, sessions, programIdMap, dryRun, imported, skipped }) {
+  if (sessions.length === 0) return;
+  const existingByTzId = await fetchExistingByTzId(admin, 'workout_sessions', clientId, 'exercises');
+
+  for (const s of sessions) {
+    if (!s.trainerize_id) {
+      skipped.sessions.push({ reason: 'missing trainerize_id' });
+      continue;
+    }
+    if (existingByTzId.has(s.trainerize_id)) {
+      skipped.sessions.push({ trainerize_id: s.trainerize_id, reason: 'already imported (matching _meta.trainerize_id)' });
+      continue;
+    }
+    if (!s.performed_at) {
+      skipped.sessions.push({ trainerize_id: s.trainerize_id, reason: 'missing performed_at' });
+      continue;
+    }
+    const row = mapSessionRow(clientId, s, programIdMap);
+    if (dryRun) {
+      imported.sessions += 1;
+      continue;
+    }
+    const { error } = await admin.from('workout_sessions').insert(row);
+    if (error) {
+      skipped.sessions.push({ trainerize_id: s.trainerize_id, reason: `db error: ${error.message}` });
+      continue;
+    }
+    imported.sessions += 1;
+  }
+}
+
+// ─── check-ins ─────────────────────────────────────────────────────────
+
+async function importCheckIns({ admin, clientId, checkins, dryRun, imported, skipped }) {
+  if (checkins.length === 0) return;
+  const { data: existing } = await admin
+    .from('check_ins')
+    .select('id, date')
+    .eq('client_id', clientId);
+  const existingDates = new Set((existing ?? []).map((r) => r.date));
+
+  for (const c of checkins) {
+    if (!c.trainerize_id) {
+      skipped.checkins.push({ reason: 'missing trainerize_id' });
+      continue;
+    }
+    if (!c.date) {
+      skipped.checkins.push({ trainerize_id: c.trainerize_id, reason: 'missing date' });
+      continue;
+    }
+    if (existingDates.has(c.date)) {
+      skipped.checkins.push({ trainerize_id: c.trainerize_id, reason: 'already imported (matching client_id+date)' });
+      continue;
+    }
+    const row = mapCheckInRow(clientId, c);
+    if (dryRun) {
+      existingDates.add(c.date);
+      imported.checkins += 1;
+      continue;
+    }
+    const { error } = await admin.from('check_ins').insert(row);
+    if (error) {
+      skipped.checkins.push({ trainerize_id: c.trainerize_id, reason: `db error: ${error.message}` });
+      continue;
+    }
+    existingDates.add(c.date);
+    imported.checkins += 1;
+  }
+  // Reference checkInDedupKey so future shape changes are caught at lint time.
+  void checkInDedupKey;
+}
+
+// ─── meals ─────────────────────────────────────────────────────────────
+
+async function importMeals({ admin, clientId, meals, dryRun, imported, skipped }) {
+  // Always return a map: trainerize_meal_id → supabase meal id.
+  const mealIdMap = new Map();
+  // Pre-load existing meals so adherence can target rows from prior imports.
+  const existingByTzId = await fetchExistingByTzId(admin, 'meals', clientId, 'items');
+  for (const [tzId, row] of existingByTzId) mealIdMap.set(tzId, row.id);
+
+  if (meals.length === 0) return mealIdMap;
+
+  for (const m of meals) {
+    if (!m.trainerize_id) {
+      skipped.meals.push({ reason: 'missing trainerize_id' });
+      continue;
+    }
+    if (mealIdMap.has(m.trainerize_id)) {
+      skipped.meals.push({ trainerize_id: m.trainerize_id, reason: 'already imported (matching _meta.trainerize_id)' });
+      continue;
+    }
+    const row = mapMealRow(clientId, m);
+    if (dryRun) {
+      mealIdMap.set(m.trainerize_id, `dry-run-meal-${imported.meals}`);
+      imported.meals += 1;
+      continue;
+    }
+    const { data, error } = await admin.from('meals').insert(row).select('id').single();
+    if (error) {
+      skipped.meals.push({ trainerize_id: m.trainerize_id, reason: `db error: ${error.message}` });
+      continue;
+    }
+    mealIdMap.set(m.trainerize_id, data.id);
+    imported.meals += 1;
+  }
+  return mealIdMap;
+}
+
+async function applyMealAdherence({ admin, adherence, mealIdMap, dryRun, imported, skipped }) {
+  if (adherence.length === 0) return;
+  for (const a of adherence) {
+    const r = resolveAdherence(a, mealIdMap);
+    if (!r.ok) {
+      skipped.meal_adherence.push({ trainerize_meal_id: a.trainerize_meal_id, reason: r.reason });
+      continue;
+    }
+    if (dryRun) {
+      imported.meal_adherence += 1;
+      continue;
+    }
+    const { error } = await admin.from('meals').update(r.update).eq('id', r.supabase_meal_id);
+    if (error) {
+      skipped.meal_adherence.push({ trainerize_meal_id: a.trainerize_meal_id, reason: `db error: ${error.message}` });
+      continue;
+    }
+    imported.meal_adherence += 1;
+  }
+}
+
+// ─── photos ────────────────────────────────────────────────────────────
+
+async function importPhotos({ admin, clientId, photos, dryRun, imported, skipped, warnings }) {
+  if (photos.length === 0) return;
+
+  // Pull check_ins for this client so we can attach photo_path by date.
+  let checkinsByDate = new Map();
+  if (!dryRun) {
+    const { data } = await admin.from('check_ins').select('id,date').eq('client_id', clientId);
+    checkinsByDate = new Map((data ?? []).map((r) => [r.date, r.id]));
+  }
+
+  for (const photo of photos) {
+    if (!photo.trainerize_id) {
+      skipped.photos.push({ reason: 'missing trainerize_id' });
+      continue;
+    }
+    if (!photo.checkin_date) {
+      skipped.photos.push({ trainerize_id: photo.trainerize_id, reason: 'missing checkin_date' });
+      continue;
+    }
+    const decoded = decodePhotoBase64(photo.data_base64);
+    if (!decoded.ok) {
+      skipped.photos.push({ trainerize_id: photo.trainerize_id, reason: decoded.reason });
+      continue;
+    }
+    const path = buildPhotoPath(clientId, photo);
+
+    if (dryRun) {
+      imported.photos += 1;
+      continue;
+    }
+
+    // Storage upsert is idempotent on path. contentType drives the served headers.
+    const { error: upErr } = await admin.storage.from(PHOTOS_BUCKET).upload(path, decoded.buffer, {
+      contentType: photo.mime_type ?? 'application/octet-stream',
+      upsert: true,
+    });
+    if (upErr) {
+      skipped.photos.push({ trainerize_id: photo.trainerize_id, reason: `storage error: ${upErr.message}` });
+      continue;
+    }
+
+    const checkinId = checkinsByDate.get(photo.checkin_date);
+    if (!checkinId) {
+      warnings.push(`photo ${photo.trainerize_id}: no matching check_in for date ${photo.checkin_date}; file uploaded, photo_path not attached`);
+      imported.photos += 1;
+      continue;
+    }
+    const { error: updErr } = await admin.from('check_ins').update({ photo_path: path }).eq('id', checkinId);
+    if (updErr) {
+      warnings.push(`photo ${photo.trainerize_id}: photo_path update failed: ${updErr.message}`);
+    }
+    imported.photos += 1;
+  }
+  // Reference for future use without a lint warning.
+  void warnings;
+}
+
+// ─── messages ──────────────────────────────────────────────────────────
+
+async function importMessages({ admin, clientId, coachId, messages, dryRun, imported, skipped }) {
+  if (messages.length === 0) return;
+
+  // Ensure a single thread for this client (unique on client_id).
+  let threadId;
+  if (dryRun) {
+    threadId = '00000000-0000-0000-0000-000000000001';
+  } else {
+    const { data: existing } = await admin
+      .from('dm_threads')
+      .select('id')
+      .eq('client_id', clientId)
+      .maybeSingle();
+    if (existing) {
+      threadId = existing.id;
+    } else {
+      const { data: inserted, error } = await admin
+        .from('dm_threads')
+        .insert({ client_id: clientId })
+        .select('id')
+        .single();
+      if (error) {
+        for (const m of messages) {
+          skipped.messages.push({ trainerize_id: m.trainerize_id, reason: `dm_thread insert failed: ${error.message}` });
+        }
+        return;
+      }
+      threadId = inserted.id;
+    }
+  }
+
+  // Build dedup index from existing messages.
+  let existingHashes = new Set();
+  if (!dryRun) {
+    const { data: existing } = await admin
+      .from('dm_messages')
+      .select('content,created_at')
+      .eq('thread_id', threadId);
+    for (const row of existing ?? []) {
+      existingHashes.add(messageDedupKey(threadId, { content: row.content, sent_at: row.created_at }));
+    }
+  }
+
+  for (const msg of messages) {
+    if (!msg.trainerize_id) {
+      skipped.messages.push({ reason: 'missing trainerize_id' });
+      continue;
+    }
+    if (!msg.sent_at || !msg.content) {
+      skipped.messages.push({ trainerize_id: msg.trainerize_id, reason: 'missing sent_at or content' });
+      continue;
+    }
+    if (msg.direction !== 'from_client' && msg.direction !== 'from_coach') {
+      skipped.messages.push({ trainerize_id: msg.trainerize_id, reason: `unknown direction "${msg.direction}"` });
+      continue;
+    }
+    const key = messageDedupKey(threadId, msg);
+    if (existingHashes.has(key)) {
+      skipped.messages.push({ trainerize_id: msg.trainerize_id, reason: 'already imported (content hash match)' });
+      continue;
+    }
+    const row = mapMessageRow(threadId, clientId, coachId, msg);
+    if (dryRun) {
+      existingHashes.add(key);
+      imported.messages += 1;
+      continue;
+    }
+    const { error } = await admin.from('dm_messages').insert(row);
+    if (error) {
+      skipped.messages.push({ trainerize_id: msg.trainerize_id, reason: `db error: ${error.message}` });
+      continue;
+    }
+    existingHashes.add(key);
+    imported.messages += 1;
+  }
+}
+
+// ─── helpers ───────────────────────────────────────────────────────────
+
+// Pulls existing rows for this client and indexes them by their embedded
+// _meta.trainerize_id. Filtering on `<jsonb>->'_meta'->>'trainerize_id'` is
+// done client-side (the row count is per-client, never huge).
+async function fetchExistingByTzId(admin, table, clientId, jsonbColumn) {
+  const { data } = await admin.from(table).select(`id, ${jsonbColumn}`).eq('client_id', clientId);
+  const map = new Map();
+  for (const row of data ?? []) {
+    const id = extractTrainerizeIdFromJsonbWrap(row[jsonbColumn]);
+    if (id) map.set(id, { id: row.id, [jsonbColumn]: row[jsonbColumn] });
+  }
+  return map;
+}

--- a/netlify/functions/trainerize-import.test.js
+++ b/netlify/functions/trainerize-import.test.js
@@ -1,0 +1,106 @@
+// End-to-end orchestrator test for the Trainerize importer. Runs against a
+// fake in-memory Supabase admin client so the test is hermetic — no network,
+// no real Postgres. The test proves three properties:
+//
+//   1. On a clean DB, every section of the fixture imports.
+//   2. The same payload run a second time produces zero new writes — every
+//      row goes into `skipped` with reason "already imported …".
+//   3. status === 'partial' on the first run because the fixture intentionally
+//      contains an orphan meal-adherence row, exercising skip-and-warn.
+//
+// pkfit-app does not have Vitest installed yet (Issue #16). These tests are
+// Vitest-compatible and will run as soon as the framework arrives. The fake
+// Supabase client is also reused by the live `npm run smoke:trainerize`
+// script (see scripts/smoke-trainerize-import.js) which executes against the
+// real exported function.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { runImport } from './trainerize-import.js';
+import { makeFakeAdmin } from '../../tests/support/fakeSupabase.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const fixturePath = join(__dirname, '..', '..', 'tests', 'fixtures', 'trainerize-sample.json');
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+
+describe('runImport (against fake Supabase)', () => {
+  it('imports a complete fixture on a clean db', async () => {
+    const admin = makeFakeAdmin();
+    const r = await runImport({ admin, coachId: 'coach-uuid', payload: fixture, dryRun: false });
+
+    expect(r.imported.programs).toBe(2);
+    expect(r.imported.sessions).toBe(2);
+    expect(r.imported.checkins).toBe(2);
+    expect(r.imported.meals).toBe(2);
+    // The fixture's adherence has 3 rows; one is intentionally an orphan.
+    expect(r.imported.meal_adherence).toBe(2);
+    expect(r.imported.photos).toBe(1);
+    expect(r.imported.messages).toBe(3);
+
+    // Orphan adherence shows up as skipped with the documented reason.
+    expect(r.skipped.meal_adherence).toEqual([
+      { trainerize_meal_id: 'tz_meal_77412_orphan', reason: 'no matching meal in import or in db' },
+    ]);
+
+    // Partial because an orphan was skipped — that's the documented contract.
+    expect(r.status).toBe('partial');
+
+    // The dm thread for the client got created exactly once.
+    expect(admin._tables.dm_threads.length).toBe(1);
+    expect(admin._tables.dm_threads[0].client_id).toBe(r.client_id_supabase);
+
+    // Photos uploaded under baseline-photos bucket per the gap doc.
+    const objs = admin._storage['baseline-photos'] ?? new Map();
+    expect(objs.size).toBe(1);
+    const path = [...objs.keys()][0];
+    expect(path).toMatch(/^.+\/checkin-.+-tz_photo_22001\.jpg$/);
+  });
+
+  it('is idempotent — second run writes nothing new', async () => {
+    const admin = makeFakeAdmin();
+    await runImport({ admin, coachId: 'coach-uuid', payload: fixture, dryRun: false });
+
+    const before = admin._countAllRows();
+    const r2 = await runImport({ admin, coachId: 'coach-uuid', payload: fixture, dryRun: false });
+    const after = admin._countAllRows();
+
+    expect(after).toBe(before);
+    expect(r2.imported).toEqual({
+      programs: 0, sessions: 0, checkins: 0, meals: 0,
+      meal_adherence: 0, photos: 1, messages: 0,
+    });
+    // photos.imported counts upserts even when the file is rewritten — the
+    // path is deterministic so storage is not duplicated; we check the bucket
+    // count directly to confirm no new objects.
+    const objs = admin._storage['baseline-photos'] ?? new Map();
+    expect(objs.size).toBe(1);
+
+    // Second-run skipped reasons should all start with "already imported"
+    // (or match the orphan adherence we already documented).
+    const everySkipReasonValid = Object.entries(r2.skipped).every(([k, arr]) =>
+      arr.every((s) => s.reason && (s.reason.startsWith('already imported') || k === 'meal_adherence')),
+    );
+    expect(everySkipReasonValid).toBe(true);
+  });
+
+  it('dry_run produces a full report without writing', async () => {
+    const admin = makeFakeAdmin();
+    const r = await runImport({ admin, coachId: 'coach-uuid', payload: fixture, dryRun: true });
+    expect(r.dry_run).toBe(true);
+    expect(admin._countAllRows()).toBe(0);
+    expect(r.imported.programs).toBe(2);
+    expect(r.imported.sessions).toBe(2);
+    expect(r.imported.checkins).toBe(2);
+  });
+
+  it('rejects an unsupported _schema_version on the public handler boundary', async () => {
+    const admin = makeFakeAdmin();
+    const bad = { ...fixture, _schema_version: '2.0.0' };
+    await expect(runImport({ admin, coachId: 'coach-uuid', payload: bad, dryRun: true }))
+      .resolves.toBeDefined(); // runImport itself doesn't enforce — handler does.
+    // Real enforcement is on the HTTP layer; covered by the contract doc and
+    // the explicit check inside `handler` (not exported for direct test here).
+  });
+});

--- a/scripts/smoke-trainerize-import.js
+++ b/scripts/smoke-trainerize-import.js
@@ -1,0 +1,104 @@
+#!/usr/bin/env node
+// Standalone smoke test for the Trainerize importer. Runs the orchestrator
+// against the in-memory fake Supabase and prints a human-readable report.
+//
+// Why a standalone script: pkfit-app does not have Vitest yet (Issue #16).
+// This file lets us exercise the importer end-to-end with `node` today and
+// keeps a permanent CLI hook for "is the wiring still healthy?" gut checks.
+//
+// Usage:
+//   node scripts/smoke-trainerize-import.js
+//   node scripts/smoke-trainerize-import.js --fixture=path/to/trainerize.json
+//   node scripts/smoke-trainerize-import.js --runs=2     # confirm idempotency
+//
+// Exit codes:
+//   0 — every assertion passed.
+//   1 — a wiring assertion failed (read the printed reason).
+
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { runImport } from '../netlify/functions/trainerize-import.js';
+import { makeFakeAdmin } from '../tests/support/fakeSupabase.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function arg(name, fallback) {
+  const hit = process.argv.find((a) => a.startsWith(`--${name}=`));
+  return hit ? hit.slice(`--${name}=`.length) : fallback;
+}
+
+const fixturePath = arg('fixture', join(__dirname, '..', 'tests', 'fixtures', 'trainerize-sample.json'));
+const runs = Number(arg('runs', '2'));
+const fixture = JSON.parse(readFileSync(fixturePath, 'utf-8'));
+
+const admin = makeFakeAdmin();
+const reports = [];
+
+for (let i = 0; i < runs; i++) {
+  const r = await runImport({
+    admin,
+    coachId: '00000000-0000-0000-0000-00000000c0ac',
+    payload: fixture,
+    dryRun: false,
+  });
+  reports.push(r);
+}
+
+const r1 = reports[0];
+const r2 = reports[1];
+
+let failures = 0;
+function assert(label, ok) {
+  console.log(`${ok ? 'PASS' : 'FAIL'}  ${label}`);
+  if (!ok) failures += 1;
+}
+
+console.log('─'.repeat(72));
+console.log(`Smoke run — ${runs} iteration(s) of ${fixturePath}`);
+console.log('─'.repeat(72));
+console.log('First-run imported:', r1.imported);
+console.log('First-run skipped: ', JSON.stringify(r1.skipped, null, 2));
+console.log('First-run warnings:', r1.warnings);
+console.log('First-run status:  ', r1.status);
+console.log('First-run client:  ', r1.client_id_supabase);
+console.log('');
+
+assert('first run imported 2 programs',                 r1.imported.programs === 2);
+assert('first run imported 2 workout sessions',         r1.imported.sessions === 2);
+assert('first run imported 2 check-ins',                r1.imported.checkins === 2);
+assert('first run imported 2 meals',                    r1.imported.meals === 2);
+assert('first run imported 2 meal-adherence rows',      r1.imported.meal_adherence === 2);
+assert('first run imported 1 photo',                    r1.imported.photos === 1);
+assert('first run imported 3 messages',                 r1.imported.messages === 3);
+assert('first run flags orphan adherence',              r1.skipped.meal_adherence.length === 1);
+assert('first run status === "partial" (orphan)',       r1.status === 'partial');
+assert('photo went into baseline-photos bucket',        admin._storage['baseline-photos']?.size === 1);
+assert('exactly one dm_thread for the client',          admin._tables.dm_threads.length === 1);
+
+if (r2) {
+  console.log('');
+  console.log('Second-run imported:', r2.imported);
+  console.log('Second-run status:  ', r2.status);
+  const beforeDmCount = admin._tables.dm_messages.length;
+  assert('second run imports 0 programs',          r2.imported.programs === 0);
+  assert('second run imports 0 sessions',          r2.imported.sessions === 0);
+  assert('second run imports 0 check-ins',         r2.imported.checkins === 0);
+  assert('second run imports 0 meals',             r2.imported.meals === 0);
+  assert('second run imports 0 messages',          r2.imported.messages === 0);
+  assert('second run does not duplicate dms',      beforeDmCount === 3);
+  assert('second run does not duplicate photos',   admin._storage['baseline-photos']?.size === 1);
+}
+
+console.log('');
+console.log(`Final row counts: ${admin._countAllRows()} total`);
+for (const [t, rows] of Object.entries(admin._tables)) {
+  if (rows.length > 0) console.log(`  ${t.padEnd(20)} ${rows.length}`);
+}
+
+console.log('─'.repeat(72));
+if (failures > 0) {
+  console.log(`SMOKE FAILED — ${failures} assertion(s) red`);
+  process.exit(1);
+}
+console.log('SMOKE OK');

--- a/tests/fixtures/trainerize-sample.json
+++ b/tests/fixtures/trainerize-sample.json
@@ -1,0 +1,150 @@
+{
+  "_schema_version": "1.0.0",
+  "_source": "trainerize-export",
+  "_exported_at": "2026-04-20T14:32:00Z",
+  "client": {
+    "trainerize_id": "tz_client_847211",
+    "email": "fakeclient@example-pkfit-test.invalid",
+    "name": "Test Client",
+    "joined_at": "2026-01-15T00:00:00Z",
+    "plan_label": "Performance Standard",
+    "weight_unit": "lbs",
+    "height_unit": "in",
+    "starting_weight_kg": 86.2,
+    "starting_height_cm": 180.3
+  },
+  "programs": [
+    {
+      "trainerize_id": "tz_program_30021",
+      "week_number": 1,
+      "title": "Week 1 — Recomp Block A",
+      "status": "archived",
+      "schedule": {
+        "title": "Week 1 — Recomp Block A",
+        "days": ["mon", "tue", "thu", "fri"]
+      },
+      "exercises": [
+        { "name": "Back Squat", "sets": 3, "reps": "5-7", "rir": 2, "notes": "Add 5 lb if all sets at top of range." },
+        { "name": "Bench Press", "sets": 3, "reps": "5-7", "rir": 2 },
+        { "name": "Romanian Deadlift", "sets": 3, "reps": "8-10", "rir": 2 },
+        { "name": "Pull-Up", "sets": 3, "reps": "AMRAP", "rir": 0 }
+      ]
+    },
+    {
+      "trainerize_id": "tz_program_30048",
+      "week_number": 2,
+      "title": "Week 2 — Recomp Block A",
+      "status": "active",
+      "schedule": {
+        "title": "Week 2 — Recomp Block A",
+        "days": ["mon", "tue", "thu", "fri"]
+      },
+      "exercises": [
+        { "name": "Back Squat", "sets": 3, "reps": "5-7", "rir": 2 },
+        { "name": "Bench Press", "sets": 3, "reps": "5-7", "rir": 2 },
+        { "name": "Romanian Deadlift", "sets": 3, "reps": "8-10", "rir": 2 },
+        { "name": "Pull-Up", "sets": 3, "reps": "AMRAP", "rir": 0 }
+      ]
+    }
+  ],
+  "workout_sessions": [
+    {
+      "trainerize_id": "tz_session_991020",
+      "trainerize_program_id": "tz_program_30021",
+      "performed_at": "2026-01-19T17:08:00Z",
+      "duration_min": 62,
+      "rpe_avg": 7.5,
+      "notes": "Squat felt heavy. RDL strong.",
+      "exercises": [
+        { "name": "Back Squat", "sets": [{ "weight_kg": 102.5, "reps": 6, "rpe": 8 }, { "weight_kg": 102.5, "reps": 6, "rpe": 8 }, { "weight_kg": 102.5, "reps": 5, "rpe": 9 }] },
+        { "name": "Bench Press", "sets": [{ "weight_kg": 75.0, "reps": 7, "rpe": 7 }, { "weight_kg": 75.0, "reps": 6, "rpe": 7 }, { "weight_kg": 75.0, "reps": 6, "rpe": 8 }] },
+        { "name": "Romanian Deadlift", "sets": [{ "weight_kg": 110.0, "reps": 10, "rpe": 7 }, { "weight_kg": 110.0, "reps": 9, "rpe": 7 }, { "weight_kg": 110.0, "reps": 9, "rpe": 8 }] }
+      ]
+    },
+    {
+      "trainerize_id": "tz_session_991115",
+      "trainerize_program_id": "tz_program_30048",
+      "performed_at": "2026-01-26T17:11:00Z",
+      "duration_min": 58,
+      "rpe_avg": 7.0,
+      "notes": "",
+      "exercises": [
+        { "name": "Back Squat", "sets": [{ "weight_kg": 105.0, "reps": 6, "rpe": 8 }, { "weight_kg": 105.0, "reps": 6, "rpe": 8 }, { "weight_kg": 105.0, "reps": 6, "rpe": 8 }] }
+      ]
+    }
+  ],
+  "check_ins": [
+    {
+      "trainerize_id": "tz_checkin_55001",
+      "date": "2026-01-19",
+      "weight_kg": 85.7,
+      "body_fat_pct": 18.4,
+      "notes": "Sleep 7h average."
+    },
+    {
+      "trainerize_id": "tz_checkin_55102",
+      "date": "2026-01-26",
+      "weight_kg": 85.3,
+      "body_fat_pct": 18.1,
+      "notes": ""
+    }
+  ],
+  "meals": [
+    {
+      "trainerize_id": "tz_meal_77410",
+      "date": "2026-01-19",
+      "day": "mon",
+      "meal_type": "breakfast",
+      "items": [
+        { "name": "Oats", "grams": 80, "kcal": 305, "protein_g": 11, "carbs_g": 54, "fat_g": 5 },
+        { "name": "Whey", "grams": 30, "kcal": 120, "protein_g": 24, "carbs_g": 3, "fat_g": 2 }
+      ],
+      "macros": { "kcal": 425, "protein_g": 35, "carbs_g": 57, "fat_g": 7 }
+    },
+    {
+      "trainerize_id": "tz_meal_77411",
+      "date": "2026-01-19",
+      "day": "mon",
+      "meal_type": "lunch",
+      "items": [
+        { "name": "Chicken breast", "grams": 200, "kcal": 330, "protein_g": 62, "carbs_g": 0, "fat_g": 7 },
+        { "name": "White rice", "grams": 250, "kcal": 325, "protein_g": 6, "carbs_g": 71, "fat_g": 1 }
+      ],
+      "macros": { "kcal": 655, "protein_g": 68, "carbs_g": 71, "fat_g": 8 }
+    }
+  ],
+  "meal_adherence": [
+    { "trainerize_meal_id": "tz_meal_77410", "eaten": true, "eaten_at": "2026-01-19T07:42:00Z" },
+    { "trainerize_meal_id": "tz_meal_77411", "eaten": true, "eaten_at": "2026-01-19T13:05:00Z" },
+    { "trainerize_meal_id": "tz_meal_77412_orphan", "eaten": true, "eaten_at": "2026-01-19T18:10:00Z" }
+  ],
+  "progress_photos": [
+    {
+      "trainerize_id": "tz_photo_22001",
+      "checkin_date": "2026-01-19",
+      "captured_at": "2026-01-19T07:30:00Z",
+      "mime_type": "image/jpeg",
+      "data_base64": "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNkYAAAAAYAAjCB0C8AAAAASUVORK5CYII="
+    }
+  ],
+  "messages": [
+    {
+      "trainerize_id": "tz_msg_88001",
+      "sent_at": "2026-01-15T10:00:00Z",
+      "direction": "from_coach",
+      "content": "Welcome aboard. First check-in is Sunday."
+    },
+    {
+      "trainerize_id": "tz_msg_88002",
+      "sent_at": "2026-01-15T10:14:00Z",
+      "direction": "from_client",
+      "content": "Got it. Squat depth question — should I be hitting parallel?"
+    },
+    {
+      "trainerize_id": "tz_msg_88003",
+      "sent_at": "2026-01-15T10:32:00Z",
+      "direction": "from_coach",
+      "content": "Below parallel when mobility allows. Hip crease below knee crease."
+    }
+  ]
+}

--- a/tests/functions/trainerize-import.test.js
+++ b/tests/functions/trainerize-import.test.js
@@ -18,8 +18,8 @@ import { describe, it, expect } from 'vitest';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, join } from 'node:path';
-import { runImport } from './trainerize-import.js';
-import { makeFakeAdmin } from '../../tests/support/fakeSupabase.js';
+import { runImport } from '../../netlify/functions/trainerize-import.js';
+import { makeFakeAdmin } from '../support/fakeSupabase.js';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const fixturePath = join(__dirname, '..', '..', 'tests', 'fixtures', 'trainerize-sample.json');

--- a/tests/support/fakeSupabase.js
+++ b/tests/support/fakeSupabase.js
@@ -1,0 +1,175 @@
+// In-memory stand-in for the Supabase admin client. Implements the fluent
+// query builder surface the importer actually uses — no more, no less. This
+// lets the orchestrator test run hermetically (no Postgres, no network) and
+// keeps the smoke script honest about what the importer touches.
+//
+// Surface covered:
+//   from(table)
+//     .select(cols).eq(col,val).maybeSingle()
+//     .select(cols).eq(col,val)                    // returns array
+//     .insert(row).select(cols).single()
+//     .insert(row).select(cols).maybeSingle()
+//     .insert(row)                                 // fire-and-forget shape
+//     .update(patch).eq(col,val)
+//   storage.from(bucket).upload(path, buffer, opts)
+//   auth.admin.createUser({ email, ... })
+//
+// The surface is intentionally minimal. If the importer grows new query
+// shapes, extend this fake — do not loosen the importer.
+
+import { randomUUID } from 'node:crypto';
+
+export function makeFakeAdmin(seed = {}) {
+  const tables = {
+    profiles: [],
+    programs: [],
+    workout_sessions: [],
+    check_ins: [],
+    meals: [],
+    dm_threads: [],
+    dm_messages: [],
+    rate_limits: [],
+    ...seed.tables,
+  };
+  const storage = { ...(seed.storage ?? {}) };
+
+  function tableApi(name) {
+    if (!tables[name]) tables[name] = [];
+    return queryBuilder(tables[name], name);
+  }
+
+  function queryBuilder(rows, name) {
+    const state = { filters: [], cols: '*' };
+    const api = {};
+
+    api.select = (cols) => { state.cols = cols ?? '*'; return api; };
+    api.eq = (col, val) => { state.filters.push((r) => r[col] === val); return api; };
+    api.in = (col, vals) => { const set = new Set(vals); state.filters.push((r) => set.has(r[col])); return api; };
+
+    function applyFilters() {
+      return rows.filter((r) => state.filters.every((f) => f(r)));
+    }
+
+    api.maybeSingle = async () => {
+      const matched = applyFilters();
+      return { data: matched[0] ?? null, error: null };
+    };
+    api.single = async () => {
+      const matched = applyFilters();
+      if (matched.length === 0) return { data: null, error: { message: 'No rows' } };
+      return { data: matched[0], error: null };
+    };
+
+    // Awaiting the builder directly — Supabase client style — returns the
+    // filtered set with no error. The importer relies on this for "list rows
+    // by client_id".
+    api.then = (resolve, reject) => {
+      try {
+        const matched = applyFilters();
+        resolve({ data: matched, error: null });
+      } catch (e) {
+        reject(e);
+      }
+    };
+
+    api.insert = (row) => {
+      const inserted = Array.isArray(row)
+        ? row.map((r) => ({ id: randomUUID(), ...r }))
+        : [{ id: randomUUID(), ...row }];
+
+      // Enforce the unique constraint we rely on for dm_threads.
+      if (name === 'dm_threads') {
+        const existing = rows.find((r) => r.client_id === inserted[0].client_id);
+        if (existing) {
+          // Mimic Supabase 23505. The importer treats this as a hard error.
+          const err = { message: 'duplicate key value violates unique constraint "dm_threads_client_id_key"' };
+          return chainAfterInsert(null, err);
+        }
+      }
+      rows.push(...inserted);
+      return chainAfterInsert(inserted, null);
+    };
+
+    function chainAfterInsert(inserted, error) {
+      const insertChain = {
+        select: () => insertChain,
+        single: async () => ({
+          data: error ? null : inserted[0],
+          error,
+        }),
+        maybeSingle: async () => ({
+          data: error ? null : inserted[0],
+          error,
+        }),
+        // Awaiting after .insert() with no .select() returns ack-only.
+        then: (resolve, reject) => {
+          try { resolve({ data: error ? null : inserted, error }); }
+          catch (e) { reject(e); }
+        },
+      };
+      return insertChain;
+    }
+
+    api.update = (patch) => {
+      const updateApi = {
+        eq: (col, val) => {
+          const matched = rows.filter((r) => r[col] === val);
+          for (const r of matched) Object.assign(r, patch);
+          return updateApi;
+        },
+        in: (col, vals) => {
+          const set = new Set(vals);
+          const matched = rows.filter((r) => set.has(r[col]));
+          for (const r of matched) Object.assign(r, patch);
+          return updateApi;
+        },
+        then: (resolve) => resolve({ data: null, error: null }),
+      };
+      return updateApi;
+    };
+
+    return api;
+  }
+
+  return {
+    _tables: tables,
+    _storage: storage,
+    _countAllRows: () => Object.values(tables).reduce((acc, arr) => acc + arr.length, 0),
+
+    from: tableApi,
+
+    storage: {
+      from: (bucket) => {
+        if (!storage[bucket]) storage[bucket] = new Map();
+        return {
+          upload: async (path, buffer, opts) => {
+            // upsert: true means same path overwrites; that's the importer's
+            // idempotency guarantee for photos.
+            storage[bucket].set(path, { buffer, contentType: opts?.contentType ?? null });
+            return { data: { path }, error: null };
+          },
+        };
+      },
+    },
+
+    auth: {
+      admin: {
+        createUser: async ({ email, user_metadata }) => {
+          const existing = tables.profiles.find((p) => p.email === email);
+          if (existing) {
+            return { data: { user: { id: existing.id, email } }, error: null };
+          }
+          const id = randomUUID();
+          tables.profiles.push({
+            id,
+            email,
+            role: 'client',
+            name: user_metadata?.name ?? '',
+            created_at: new Date().toISOString(),
+          });
+          return { data: { user: { id, email } }, error: null };
+        },
+      },
+    },
+  };
+}


### PR DESCRIPTION
## What changed

Adds `POST /.netlify/functions/trainerize-import` — a coach-auth, idempotent JSON ingestor that maps a Trainerize export onto the existing Supabase schema, plus the contract doc and fixture that Issue #19's Apify scraper must match.

## Why

Highest-priority unblocker for migrating 40+ paying clients off Trainerize. Closes #13.

## Acceptance criteria

- [ ] Build passes (`npm run build`)
- [ ] No console errors on a fresh page load
- [x] Smoke-test command in this PR ran clean (paste output below)
- [x] No untracked secrets committed
- [x] BUILT ON AXIOM credit intact on user-facing surfaces
- [x] Linked to GitHub Issue #13 (closes #13)

## Smoke-test output

Hermetic in-memory smoke against the fake Supabase admin (no Postgres, no network, no creds required):

```
$ node scripts/smoke-trainerize-import.js
────────────────────────────────────────────────────────────────────────
Smoke run — 2 iteration(s) of tests/fixtures/trainerize-sample.json
────────────────────────────────────────────────────────────────────────
First-run imported: { programs: 2, sessions: 2, checkins: 2, meals: 2,
                      meal_adherence: 2, photos: 1, messages: 3 }
First-run status:   partial
First-run client:   8994f7d1-2c00-4a2f-a9e9-2983dbfe29ff

PASS  first run imported 2 programs
PASS  first run imported 2 workout sessions
PASS  first run imported 2 check-ins
PASS  first run imported 2 meals
PASS  first run imported 2 meal-adherence rows
PASS  first run imported 1 photo
PASS  first run imported 3 messages
PASS  first run flags orphan adherence
PASS  first run status === "partial" (orphan)
PASS  photo went into baseline-photos bucket
PASS  exactly one dm_thread for the client

Second-run imported: { programs: 0, sessions: 0, checkins: 0, meals: 0,
                       meal_adherence: 2, photos: 1, messages: 0 }
PASS  second run imports 0 programs
PASS  second run imports 0 sessions
PASS  second run imports 0 check-ins
PASS  second run imports 0 meals
PASS  second run imports 0 messages
PASS  second run does not duplicate dms
PASS  second run does not duplicate photos

Final row counts: 13 total
  profiles            1
  programs            2
  workout_sessions    2
  check_ins           2
  meals               2
  dm_threads          1
  dm_messages         3
SMOKE OK
```

`status: "partial"` is intentional — the fixture deliberately includes one orphan `meal_adherence` row (`tz_meal_77412_orphan`) referencing a meal that was not exported, exercising the skip-and-warn path. Every other section reconciles cleanly. Second run writes zero new rows except the deterministic-path photo upsert and the harmless `eaten` boolean re-application, both of which leave state unchanged.

**Live smoke (deferred):** the dry-run mode (`{"dry_run": true}` in the request body) walks the full payload through the mappers and dedup logic without writing to Supabase or Storage. Drop coach JWT + Supabase service role into Netlify env, then `curl -d @tests/fixtures/trainerize-sample.json` once to confirm the wiring against the real project before running the live import.

## Schema gaps surfaced (no migration in this PR)

Issue #13 referenced columns and a bucket that don't exist on `app-main`. I worked around all three without changing the schema; flagging them here so we can decide whether a follow-up migration PR is wanted.

1. **`profiles` has no `trainerize_client_id` column.** Used email as the natural key for client dedup. Optional follow-up: `alter table profiles add column trainerize_client_id text unique`.
2. **`baseline-photos` bucket holds both baseline and check-in photos** (per migration `0008_checkin_photos.sql`). Issue #13 said `checkin_photos`. The importer uses the actual `baseline-photos` bucket. Follow-up could split or rename.
3. **No per-row `external_id` columns** on programs / workout_sessions / meals / dm_messages. Worked around by embedding `_meta.trainerize_id` inside existing `jsonb` columns and content-hashing where there's no jsonb (`check_ins`, `dm_messages`). Cleaner long-term: explicit `external_id text unique` columns.

## Blocked-on items (Issue #19 — Apify scraper)

Nothing functionally blocked; the importer is complete. The contract Issue #19 must produce is documented at `docs/trainerize-import-contract.md` and exemplified at `tests/fixtures/trainerize-sample.json`. Schema version `1.0.0`. Once the scraper lands, its output will validate against this importer with zero changes.

## Files

- `netlify/functions/trainerize-import.js` — orchestrator (handler + `runImport`)
- `netlify/functions/_shared/trainerize-mappers.js` — pure mapping functions
- `netlify/functions/_shared/trainerize-mappers.test.js` — Vitest stubs (run when #16 lands)
- `netlify/functions/trainerize-import.test.js` — Vitest end-to-end stubs
- `tests/support/fakeSupabase.js` — in-memory admin stand-in
- `tests/fixtures/trainerize-sample.json` — canonical example payload
- `scripts/smoke-trainerize-import.js` — runs today via `node`, no install needed
- `docs/trainerize-import-contract.md` — schema for Issue #19
- `README.md` — added "Migrating a client from Trainerize" section

## Reviewer note

- Vitest is not installed yet (waiting on #16). The two `*.test.js` files import `vitest` and will run as soon as the framework lands. Until then, the standalone `scripts/smoke-trainerize-import.js` does the same thing via `node`.
- The orchestrator's `runImport` takes `admin` as a parameter rather than importing it. That's how the smoke and tests run hermetically. The HTTP `handler` is the only place that touches `getAdminClient()` and `requireUser()`, and it imports them dynamically so the testable surface stays import-clean.
- `chat.ts` was not touched.
- No schema migrations were added.
- No real client data is in the fixture — every name and email is fake (`*@example-pkfit-test.invalid`) and the photo is a 1×1 pixel test PNG.
