### PR TITLE
feat(ops): AXIOM Overseer scheduled function — daily build brief

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -27,3 +27,12 @@ STRIPE_PRICE_FULL_MONTHLY=price_xxx
 STRIPE_PRICE_FULL_ANNUAL=price_xxx
 STRIPE_PRICE_PREMIUM_MONTHLY=price_xxx
 STRIPE_PRICE_PREMIUM_ANNUAL=price_xxx
+
+# ─── AXIOM OVERSEER (scheduled function — daily build brief) ──────────────
+# Personal access token (or fine-grained) with read access to issues + PRs.
+GITHUB_TOKEN=ghp_xxx
+GITHUB_OWNER=percyhendrux123-prog
+GITHUB_REPO=PKFIT-architect-
+# Dedicated Slack incoming webhook for ops chatter (e.g. #axiom-build-ops or
+# Percy's DM). Do NOT reuse a customer-facing webhook here.
+SLACK_WEBHOOK_URL_OPS=https://hooks.slack.com/services/xxx/yyy/zzz

--- a/README.md
+++ b/README.md
@@ -243,6 +243,40 @@ node scripts/smoke-trainerize-import.js
 
 These markers are non-invasive — no schema migration is required. A future migration could add explicit `external_id text unique` columns for cleaner audit; flagged in the import contract doc.
 
+## How AXIOM Overseer works
+
+AXIOM Overseer is a Netlify scheduled function that posts a daily editor's brief
+on the pkfit-app build to Slack. It sits above the bench — it does not ship
+code. It reads the GitHub repo, synthesizes what matters (open PRs and their CI
+state, issues by priority, 24-hour merge velocity, blockers), and posts a single
+markdown block once a day.
+
+- Source: `netlify/functions/axiom-overseer.js`
+- Schedule: `0 13 * * *` UTC (08:00 CT during CDT, 07:00 CT during CST). See
+  the comment in `netlify.toml` for seasonal handling.
+- Required env vars (Netlify dashboard, never committed):
+  - `GITHUB_TOKEN` — repo-read scope, no write
+  - `GITHUB_OWNER`, `GITHUB_REPO` — defaulted to this repo if unset
+  - `SLACK_WEBHOOK_URL_OPS` — dedicated ops webhook; **do not** point at a
+    customer-facing channel
+  - `DRY_RUN=1` — disables Slack post and returns the rendered markdown in the
+    function response (used by `npm run axiom:smoke`)
+
+To smoke-test locally:
+
+```
+GITHUB_TOKEN=ghp_xxx DRY_RUN=1 npm run axiom:smoke
+```
+
+The output is the exact markdown that would land in Slack. Paste it into a
+Slack preview to verify formatting before flipping `DRY_RUN`.
+
+To trigger the deployed function on demand (after deploy):
+
+```
+netlify functions:invoke axiom-overseer --no-identity
+```
+
 ## License
 
 Proprietary. All rights reserved.

--- a/netlify.toml
+++ b/netlify.toml
@@ -19,6 +19,13 @@
 [functions."client-assistant"]
   included_files = ["netlify/functions/_prompts/*"]
 
+
+[functions."axiom-overseer"]
+  # Daily editor's morning brief. 13:00 UTC = 08:00 CT during CDT.
+  # During CST (winter), this lands at 07:00 CT. If a strict 08:00-CT-year-round
+  # is required, switch the schedule by season or move to a Cowork-loop runner.
+  schedule = "0 13 * * *"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/functions/axiom-overseer.js
+++ b/netlify/functions/axiom-overseer.js
@@ -1,0 +1,307 @@
+// netlify/functions/axiom-overseer.js
+//
+// AXIOM Overseer — daily editor's morning brief.
+//
+// Scheduled function. Reads the GitHub repo, synthesizes what matters across
+// the bench (open PRs, issues by priority, 24h velocity, blockers), and posts
+// a single markdown block to a dedicated Slack ops webhook.
+//
+// Sits ABOVE the bench. Doesn't ship code. Reads, synthesizes, posts.
+//
+// Schedule: defined in netlify.toml (`0 13 * * *` = 08:00 CT during CDT).
+//
+// Env (set in Netlify dashboard, never committed):
+//   GITHUB_TOKEN          — PAT or fine-grained token, repo:read scope
+//   GITHUB_OWNER          — defaults to "percyhendrux123-prog"
+//   GITHUB_REPO           — defaults to "PKFIT-architect-"
+//   SLACK_WEBHOOK_URL_OPS — incoming webhook for #axiom-build-ops (or DM)
+//   DRY_RUN               — "1" to skip Slack post; returns rendered markdown
+//                            in the function response (used by axiom:smoke)
+
+const GH_API = 'https://api.github.com';
+
+const cfg = () => ({
+  token: process.env.GITHUB_TOKEN,
+  owner: process.env.GITHUB_OWNER || 'percyhendrux123-prog',
+  repo: process.env.GITHUB_REPO || 'PKFIT-architect-',
+  // The branch the bench actually merges into. Velocity is measured here.
+  buildBranch: process.env.GITHUB_BUILD_BRANCH || 'app-main',
+  slackUrl: process.env.SLACK_WEBHOOK_URL_OPS,
+  dryRun: process.env.DRY_RUN === '1',
+});
+
+// ─── HTTP helpers ────────────────────────────────────────────────────────────
+
+async function gh(path, { token }) {
+  const res = await fetch(`${GH_API}${path}`, {
+    headers: {
+      Accept: 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28',
+      'User-Agent': 'axiom-overseer/1.0',
+      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    },
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`GitHub ${res.status} on ${path}: ${body.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+// ─── Data fetchers ───────────────────────────────────────────────────────────
+
+async function fetchOpenPRs(c) {
+  const prs = await gh(
+    `/repos/${c.owner}/${c.repo}/pulls?state=open&per_page=50&sort=updated&direction=desc`,
+    c,
+  );
+  // Enrich with CI status (combined check-runs from the head sha).
+  const enriched = await Promise.all(
+    prs.map(async (p) => {
+      let ci = 'unknown';
+      try {
+        const checks = await gh(
+          `/repos/${c.owner}/${c.repo}/commits/${p.head.sha}/check-runs?per_page=20`,
+          c,
+        );
+        const runs = checks.check_runs || [];
+        if (runs.length === 0) ci = 'no checks';
+        else if (runs.some((r) => r.status !== 'completed')) ci = 'pending';
+        else if (runs.every((r) => r.conclusion === 'success')) ci = 'green';
+        else if (runs.some((r) => r.conclusion === 'failure')) ci = 'failing';
+        else ci = runs.map((r) => r.conclusion).filter(Boolean).join(',') || 'mixed';
+      } catch (e) {
+        ci = `err:${e.message.slice(0, 30)}`;
+      }
+      return {
+        number: p.number,
+        title: p.title,
+        author: p.user?.login || 'unknown',
+        url: p.html_url,
+        ci,
+        updatedAt: p.updated_at,
+        createdAt: p.created_at,
+        draft: p.draft,
+        ageHours: (Date.now() - new Date(p.updated_at).getTime()) / 36e5,
+      };
+    }),
+  );
+  return enriched;
+}
+
+async function fetchOpenIssuesByPriority(c) {
+  // Pull all open issues (excluding PRs — GitHub returns both from this endpoint).
+  const all = await gh(
+    `/repos/${c.owner}/${c.repo}/issues?state=open&per_page=100`,
+    c,
+  );
+  const issues = all.filter((i) => !i.pull_request);
+  const bucket = (label) =>
+    issues
+      .filter((i) => i.labels.some((l) => l.name === label))
+      .map((i) => ({ number: i.number, title: i.title, url: i.html_url }));
+  return {
+    high: bucket('priority:high'),
+    medium: bucket('priority:medium'),
+  };
+}
+
+async function fetchRecentlyClosedIssues(c) {
+  const since = new Date(Date.now() - 7 * 24 * 36e5).toISOString();
+  const closed = await gh(
+    `/repos/${c.owner}/${c.repo}/issues?state=closed&since=${since}&per_page=50&sort=updated&direction=desc`,
+    c,
+  );
+  return closed
+    .filter((i) => !i.pull_request)
+    .slice(0, 3)
+    .map((i) => ({ number: i.number, title: i.title, url: i.html_url }));
+}
+
+async function fetchVelocity24h(c) {
+  const sinceIso = new Date(Date.now() - 24 * 36e5).toISOString();
+
+  // Merged PRs in last 24h. PRs endpoint can't filter by merged_at; sort by
+  // updated and stop early.
+  const recent = await gh(
+    `/repos/${c.owner}/${c.repo}/pulls?state=closed&base=${c.buildBranch}&per_page=50&sort=updated&direction=desc`,
+    c,
+  );
+  const merged24h = recent.filter(
+    (p) => p.merged_at && new Date(p.merged_at).getTime() > Date.now() - 24 * 36e5,
+  );
+
+  // Sum +/- across those PRs (each fetch needed for additions/deletions).
+  let additions = 0;
+  let deletions = 0;
+  for (const p of merged24h) {
+    try {
+      const full = await gh(`/repos/${c.owner}/${c.repo}/pulls/${p.number}`, c);
+      additions += full.additions || 0;
+      deletions += full.deletions || 0;
+    } catch {
+      /* skip — best-effort line counts */
+    }
+  }
+
+  // Top contributor by commit count in the last 24h.
+  const commits = await gh(
+    `/repos/${c.owner}/${c.repo}/commits?sha=${c.buildBranch}&since=${sinceIso}&per_page=100`,
+    c,
+  );
+  const tally = {};
+  for (const c2 of commits) {
+    const who = c2.author?.login || c2.commit?.author?.name || 'unknown';
+    tally[who] = (tally[who] || 0) + 1;
+  }
+  const top = Object.entries(tally).sort((a, b) => b[1] - a[1])[0];
+
+  return {
+    mergedCount: merged24h.length,
+    additions,
+    deletions,
+    topContributor: top ? `${top[0]} (${top[1]})` : 'none',
+  };
+}
+
+// ─── Renderer ────────────────────────────────────────────────────────────────
+
+function fmtPR(p) {
+  const blocker = p.ci === 'failing' ? ' — CI red' : p.draft ? ' — draft' : '';
+  const stale = p.ageHours > 24 ? ` — stale ${Math.round(p.ageHours)}h` : '';
+  const updated = new Date(p.updatedAt).toISOString().slice(0, 16).replace('T', ' ');
+  return `- #${p.number} — ${p.title} — ${p.author} — CI: ${p.ci} — last update ${updated}Z${blocker}${stale}`;
+}
+
+function fmtIssueList(items) {
+  if (items.length === 0) return '_(none)_';
+  return items.map((i) => `  - #${i.number} — ${i.title}`).join('\n');
+}
+
+function render({ date, prs, issues, recentlyClosed, velocity }) {
+  const stalePRs = prs.filter((p) => p.ageHours > 24 && !p.draft);
+  const failingPRs = prs.filter((p) => p.ci === 'failing');
+
+  const blockerLines = [];
+  if (stalePRs.length > 0) {
+    for (const p of stalePRs) {
+      blockerLines.push(
+        `- PR awaiting review > 24h: #${p.number} ${p.title} (${Math.round(p.ageHours)}h)`,
+      );
+    }
+  }
+  if (failingPRs.length > 0) {
+    for (const p of failingPRs) {
+      blockerLines.push(`- Failing CI: #${p.number} ${p.title} — ${p.url}`);
+    }
+  }
+  if (blockerLines.length === 0) blockerLines.push('- None.');
+
+  // One-sentence recommendation. Mechanism-first, no hype.
+  let rec;
+  if (failingPRs.length > 0) {
+    rec = `Land the red CI on #${failingPRs[0].number} before opening anything new.`;
+  } else if (stalePRs.length > 0) {
+    rec = `Clear the stalest PR (#${stalePRs[0].number}, ${Math.round(stalePRs[0].ageHours)}h) — review or close.`;
+  } else if (issues.high.length > 0) {
+    rec = `Pick up high-priority issue #${issues.high[0].number} — nothing on the bench is blocked.`;
+  } else if (prs.length > 0) {
+    rec = `Bench is healthy. Merge what's reviewable, then start the next high-priority issue.`;
+  } else {
+    rec = `Quiet day. Use it to harden tests or write the next ADR.`;
+  }
+
+  return [
+    `*Axiom Overseer — pkfit-app build, ${date}*`,
+    ``,
+    `*Open PRs (state)* ▸`,
+    prs.length === 0 ? '_(none)_' : prs.map(fmtPR).join('\n'),
+    ``,
+    `*Issues by priority* ▸`,
+    `*high (open):* ${issues.high.length}`,
+    fmtIssueList(issues.high),
+    `*medium (open):* ${issues.medium.length}`,
+    fmtIssueList(issues.medium),
+    recentlyClosed.length === 0
+      ? `*recently closed:* _(none in last 7d)_`
+      : `*recently closed:*\n${fmtIssueList(recentlyClosed)}`,
+    ``,
+    `*Build velocity* ▸`,
+    `- Merged in last 24h: ${velocity.mergedCount} ${velocity.mergedCount === 1 ? 'PR' : 'PRs'}`,
+    `- Lines changed: +${velocity.additions} / -${velocity.deletions}`,
+    `- Top contributor (by commits): ${velocity.topContributor}`,
+    ``,
+    `*Blockers* ▸`,
+    blockerLines.join('\n'),
+    ``,
+    `*Today's recommendation* ▸`,
+    rec,
+  ].join('\n') + '\n';
+}
+
+// ─── Slack post ──────────────────────────────────────────────────────────────
+
+async function postToSlack(text, c) {
+  const res = await fetch(c.slackUrl, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text, mrkdwn: true }),
+  });
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`Slack ${res.status}: ${body.slice(0, 200)}`);
+  }
+}
+
+// ─── Handler ─────────────────────────────────────────────────────────────────
+
+export const handler = async () => {
+  const c = cfg();
+  if (!c.token) {
+    if (!c.dryRun) {
+      return { statusCode: 500, body: JSON.stringify({ error: 'GITHUB_TOKEN missing' }) };
+    }
+    // eslint-disable-next-line no-console
+    console.warn('[axiom-overseer] GITHUB_TOKEN unset — falling back to unauthenticated API (rate-limited, public repos only).');
+  }
+  if (!c.dryRun && !c.slackUrl) {
+    return {
+      statusCode: 500,
+      body: JSON.stringify({ error: 'SLACK_WEBHOOK_URL_OPS missing (or set DRY_RUN=1)' }),
+    };
+  }
+
+  try {
+    const [prs, issues, recentlyClosed, velocity] = await Promise.all([
+      fetchOpenPRs(c),
+      fetchOpenIssuesByPriority(c),
+      fetchRecentlyClosedIssues(c),
+      fetchVelocity24h(c),
+    ]);
+
+    const date = new Date().toISOString().slice(0, 10);
+    const text = render({ date, prs, issues, recentlyClosed, velocity });
+
+    if (c.dryRun) {
+      // Body holds the rendered markdown; caller decides what to do with it.
+      return { statusCode: 200, body: text };
+    }
+
+    await postToSlack(text, c);
+    return { statusCode: 200, body: JSON.stringify({ ok: true, posted: true }) };
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error('axiom-overseer failed:', err);
+    return { statusCode: 500, body: JSON.stringify({ error: err.message }) };
+  }
+};
+
+// Exported for the smoke-test runner (scripts/axiom-smoke.js).
+export const __internals = {
+  render,
+  fetchOpenPRs,
+  fetchOpenIssuesByPriority,
+  fetchRecentlyClosedIssues,
+  fetchVelocity24h,
+  cfg,
+};

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "lint": "eslint src",
     "test": "vitest run",
     "test:watch": "vitest",
-    "test:coverage": "vitest run --coverage"
+    "test:coverage": "vitest run --coverage",
+    "axiom:smoke": "node scripts/axiom-smoke.js"
   },
   "dependencies": {
     "@pkfit/ui": "*",

--- a/scripts/axiom-smoke.js
+++ b/scripts/axiom-smoke.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+// scripts/axiom-smoke.js — local dry-run for the AXIOM Overseer function.
+// Imports the handler, forces DRY_RUN, prints the rendered markdown to stdout.
+// Usage:  GITHUB_TOKEN=ghp_xxx node scripts/axiom-smoke.js
+import { handler } from '../netlify/functions/axiom-overseer.js';
+
+process.env.DRY_RUN = '1';
+
+const res = await handler({}, {});
+if (res.statusCode !== 200) {
+  console.error('FAILED:', res.body);
+  process.exit(1);
+}
+// In DRY_RUN, body IS the rendered markdown.
+process.stdout.write(res.body);


### PR DESCRIPTION
## What changed

Adds a Netlify scheduled function `netlify/functions/axiom-overseer.js`
that posts a daily editor's brief to Slack on pkfit-app build state.
Sits above the bench. Does not ship code. Reads, synthesizes, posts.

## Why

We need a once-a-day pulse on what's happening across the multi-agent
build — open PRs, CI status, priority issue queue, 24h velocity,
blockers — without manually checking GitHub each morning. AXIOM is the
editor's eyes-and-ears.

## Acceptance criteria

- [x] Build passes (`npm run build`) — function bundled by esbuild, no source-tree changes that affect the React app
- [x] No console errors on a fresh page load
- [x] Smoke-test command in this PR ran clean (paste output below)
- [x] No untracked secrets committed
- [x] BUILT ON AXIOM credit intact on user-facing surfaces
- [x] Linked to GitHub Issue #23 (closes #23)

## Smoke-test output

```
GITHUB_TOKEN=ghp_xxx DRY_RUN=1 npm run axiom:smoke
```

(see sample-slack-output.md in the agent handoff bundle for the verbatim render against the live repo on 2026-04-25)

## Reviewer note

- Schedule is `0 13 * * *` UTC = 08:00 CT during CDT, 07:00 CT during
  CST. Comment in netlify.toml flags this.
- Function uses a *separate* `SLACK_WEBHOOK_URL_OPS` env var, NOT the
  customer-facing `SLACK_WEBHOOK_URL` that may exist later for
  intake/checkin chats. Keep these wires separated.
- `GITHUB_TOKEN` should be a fine-grained PAT scoped read-only to this
  repo.
- The function falls back to unauthenticated GitHub API in DRY_RUN mode
  only (so smoke tests work without a token); production runs require
  the token and the Slack webhook.
- No lint coverage: `eslint.config.js` already ignores
  `netlify/functions/**`. The file is plain ESM JS; `node --check` is
  green.
