### PR TITLE
feat(ui): extract canonical ATLAS chat components into @pkfit/ui (closes #17)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,11 @@
     "": {
       "name": "pkfit-app",
       "version": "1.0.0",
+      "workspaces": [
+        "packages/*"
+      ],
       "dependencies": {
+        "@pkfit/ui": "*",
         "@stripe/stripe-js": "^4.8.0",
         "@supabase/supabase-js": "^2.45.4",
         "lucide-react": "^0.454.0",
@@ -1086,6 +1090,10 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@pkfit/ui": {
+      "resolved": "packages/pkfit-ui",
+      "link": true
     },
     "node_modules/@remix-run/router": {
       "version": "1.23.2",
@@ -6121,6 +6129,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/pkfit-ui": {
+      "name": "@pkfit/ui",
+      "version": "0.1.0",
+      "peerDependencies": {
+        "react": ">=18.0.0",
+        "react-dom": ">=18.0.0"
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "1.0.0",
   "type": "module",
+  "workspaces": [
+    "packages/*"
+  ],
   "scripts": {
     "dev": "vite",
     "build": "vite build",
@@ -10,6 +13,7 @@
     "lint": "eslint src"
   },
   "dependencies": {
+    "@pkfit/ui": "*",
     "@stripe/stripe-js": "^4.8.0",
     "@supabase/supabase-js": "^2.45.4",
     "lucide-react": "^0.454.0",

--- a/packages/pkfit-ui/MIGRATION.md
+++ b/packages/pkfit-ui/MIGRATION.md
@@ -1,0 +1,68 @@
+# Migration paths — adopting `@pkfit/ui`
+
+This PR introduces `@pkfit/ui` as the canonical React source for the ATLAS
+chat-UI pattern. None of the three target surfaces consume it yet.
+Below are the migration paths for follow-up PRs.
+
+## 1. `pkfit-intake-deploy` (currently vanilla HTML)
+
+**Today:** `public/index.html` is a single 930-line file. CSS in `<style>`,
+ATLAS tokens at the top, JS at the bottom hand-builds DOM (`document.createElement`,
+`addTurn()`, `chipsEl()`, `emailCard()`, `nextStepCard()`, `ctaCard()`).
+
+**Migration shape:**
+- Convert the project to a Vite + React app (npm init vite@latest, react template).
+- Add `@pkfit/ui` as a dependency (workspace link, or publish to npm registry first).
+- Move the page shell (header, axiom credit, app grid divs) into `App.jsx`.
+- Replace `addTurn(...)` calls with `<Turn>...</Turn>` JSX.
+- Replace `chipsEl(...)` / `emailCard(...)` / `nextStepCard(...)` / `ctaCard(...)`
+  with the named components from `@pkfit/ui`.
+- Move flow logic (askName, askGoal, etc.) into a reducer or hook in the
+  intake app — `@pkfit/ui` does not own flow state.
+- Delete the inline `<style>` block in favor of `import '@pkfit/ui/tokens.css'`.
+- Keep the `/api/chat` Netlify function untouched.
+
+**Estimated diff:** ~1 net file change in app code (index.html → src/main.jsx +
+small App.jsx + flow.js), plus the package.json/vite scaffolding.
+
+## 2. `pkfit-checkin-deploy` (currently vanilla HTML)
+
+**Today:** `public/index.html` is a single 1,170-line file. Same architecture
+as intake plus `sliderCard()`, `photoCard()`, `streakCard()`, and the
+`#streakPill` header element.
+
+**Migration shape:**
+- Same Vite + React conversion as intake.
+- Replace `sliderCard()` → `<SliderCard>`, `streakCard()` → `<StreakCard>`,
+  shared chip/cta builders → `<Chips>` / `<CtaCard>`.
+- `photoCard()` is **not** part of `@pkfit/ui` v0.1.0 — it has app-specific
+  upload behavior. Keep it local in the check-in app, or propose a `PhotoCard`
+  addition to `@pkfit/ui` in a follow-up.
+- The `#streakPill` in the header is also app-local — leave it in the
+  check-in app's `App.jsx`.
+- Persist localStorage logic (`STORAGE_KEY = 'pkfit-checkin-v1'`) untouched.
+
+**Estimated diff:** larger than intake because of the slider, photo, and
+streak surfaces; still a single-app rewrite of one file.
+
+## 3. `pkfit-app` — `src/pages/client/Assistant.jsx`
+
+**Today:** 225-line React component using Tailwind + the local
+`components/ui/Button` and `components/ContextPinMenu`. **Does not use any
+ATLAS classes today** — different visual treatment entirely.
+
+**Migration shape:**
+- This is a **redesign**, not a refactor. Adopting `@pkfit/ui` means
+  switching the in-app coach surface from the current Tailwind/Card style to
+  the ATLAS dark/cream/moon treatment.
+- Requires a UX call from Percy first. Visual change is significant.
+- If approved: add `import '@pkfit/ui/tokens.css'` to `src/main.jsx`,
+  rewrite `Assistant.jsx` to use `<Turn>`, `<Bubble>`, `<ComposerWrap>`
+  for the conversation panel. Keep the conversation list sidebar as-is or
+  redesign separately.
+- The page shell (header + app grid) doesn't exist in pkfit-app yet — those
+  ATLAS app-shell elements would need to be added if you want full visual
+  parity with intake/checkin.
+
+**Estimated diff:** 1 file rewrite (Assistant.jsx) + tokens.css import +
+optional new shell components. Out of scope for this PR.

--- a/packages/pkfit-ui/README.md
+++ b/packages/pkfit-ui/README.md
@@ -1,0 +1,111 @@
+# @pkfit/ui
+
+Canonical React components for the **PKFIT ATLAS chat-UI pattern** (Stage 0.5).
+
+This is a private workspace package inside the `pkfit-app` monorepo. It is the
+single source of truth for the chat surface used by the intake, check-in, and
+in-app coach experiences.
+
+## Why this exists
+
+Before this package, the same Stage 0.5 chat pattern (turns, bubbles, chips,
+slider/streak/CTA cards, composer, etc.) was hand-rolled inline in two places:
+
+- `pkfit-intake-deploy/public/index.html` (vanilla DOM, ~930 lines)
+- `pkfit-checkin-deploy/public/index.html` (vanilla DOM, ~1,170 lines)
+
+The pkfit-app React code did **not** yet have an ATLAS chat surface — its
+in-app `Assistant.jsx` uses Tailwind + the local `ui/Card`/`ui/Button` set.
+
+This package establishes the canonical React form so all three surfaces can
+converge on a single visual + behavioral source of truth in subsequent PRs.
+ATLAS canon (tokens, grid, axiom credit) is mirrored from `~/Desktop/ATLAS.md`.
+
+## Components
+
+| Export | Source pattern | Notes |
+|---|---|---|
+| `Turn` | both | role='agent'/'client', who, optional timestamp |
+| `Bubble` | both | typing/caret variants for streamed output |
+| `Chip` / `Chips` | both | quick-reply pills, ghostLast option |
+| `SliderCard` | check-in `sliderCard` | 1-10 default, configurable submit copy |
+| `StreakCard` | check-in `streakCard` | large serif numeral + optional cue |
+| `CtaCard` | both | yes/no soft cross-sell |
+| `ComposerWrap` | both | fixed-bottom pill input + send button |
+| `EmailCard` | intake `emailCard` | validated email input |
+| `NextStepCard` | intake `nextStepCard` | italic-serif end-of-flow cue |
+
+All components self-fade/disable after a terminal interaction, matching the
+animation defaults in the source HTML.
+
+## Usage
+
+```jsx
+// 1. Import the tokens stylesheet ONCE in your app entry (e.g. main.jsx).
+import '@pkfit/ui/tokens.css';
+
+// 2. Use components anywhere.
+import { Turn, Bubble, Chips, SliderCard, ComposerWrap } from '@pkfit/ui';
+
+function Example() {
+  return (
+    <>
+      <Turn role="agent" who="PK">
+        <Bubble>How was the week?</Bubble>
+      </Turn>
+
+      <Chips
+        options={[
+          { label: 'Strong', value: 'strong' },
+          { label: 'Drained', value: 'drained' },
+        ]}
+        onPick={(opt) => console.log(opt.value)}
+      />
+
+      <SliderCard
+        label="Energy through the week"
+        onSubmit={(v) => console.log(v)}
+      />
+
+      <ComposerWrap
+        placeholder="Type a reply…"
+        onSubmit={(text) => console.log(text)}
+      />
+    </>
+  );
+}
+```
+
+The components do not render their own page-shell (header, app grid,
+notches, axiom credit). Those remain the host app's responsibility — they
+live in tokens.css comments only as ATLAS reference.
+
+## Contribution rules
+
+1. **No new visual behavior here.** This package is the single source of
+   truth for the ATLAS chat pattern. If you need a new variant, propose it
+   in ATLAS.md first, then update this package.
+2. **Faithful to the HTML source.** Every component in v0.1.0 is a direct
+   translation of the corresponding `xxxCard()` builder in
+   `pkfit-intake-deploy` or `pkfit-checkin-deploy`. Animations, defaults,
+   and post-pick fade behaviors must match.
+3. **Tokens-driven.** Colors, fonts, radii — all via CSS custom properties
+   in `tokens.css`. No hard-coded hex inside components.
+4. **No app-specific logic.** Flow control (which card to show next, what
+   to do with the answer) belongs in the host app, not in `@pkfit/ui`.
+5. **Named exports only.** Default exports are forbidden; the index re-exports
+   each component by name so tree-shaking stays predictable.
+6. **No required peer deps beyond React 18.** Don't pull in icon libraries,
+   form libraries, or anything else. Inline SVGs only.
+
+## Versioning
+
+Private package, semver-loose. Bump `package.json` `version` whenever you
+change a component's prop contract or visual behavior.
+
+## See also
+
+- [`MIGRATION.md`](./MIGRATION.md) — adoption path for `pkfit-intake-deploy`,
+  `pkfit-checkin-deploy`, and `pkfit-app`'s `Assistant.jsx`.
+- ATLAS canon: `~/Desktop/ATLAS.md`
+- Originating issue: [#17](https://github.com/percyhendrux123-prog/PKFIT-architect-/issues/17)

--- a/packages/pkfit-ui/package.json
+++ b/packages/pkfit-ui/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@pkfit/ui",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Canonical React components for the PKFIT ATLAS chat-UI pattern (Stage 0.5).",
+  "type": "module",
+  "main": "./src/index.js",
+  "module": "./src/index.js",
+  "exports": {
+    ".": "./src/index.js",
+    "./tokens.css": "./src/tokens.css"
+  },
+  "files": [
+    "src"
+  ],
+  "peerDependencies": {
+    "react": ">=18.0.0",
+    "react-dom": ">=18.0.0"
+  },
+  "sideEffects": [
+    "*.css"
+  ]
+}

--- a/packages/pkfit-ui/src/Bubble.jsx
+++ b/packages/pkfit-ui/src/Bubble.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+/**
+ * Bubble — the message body inside a Turn. Visual treatment differs based on
+ * whether the parent Turn has the client or agent class (handled in tokens.css).
+ *
+ * Props:
+ *   children    Bubble content. Strings render as-is; complex children render literally.
+ *   typing      If true, renders the three-dot typing indicator instead of children.
+ *   caret       If true, appends a blinking caret (used during streamed output).
+ */
+export function Bubble({ children, typing = false, caret = false }) {
+  if (typing) {
+    return (
+      <div className="pk-bubble">
+        <div className="pk-typing">
+          <span /><span /><span />
+        </div>
+      </div>
+    );
+  }
+  return (
+    <div className="pk-bubble">
+      {children}
+      {caret && <span className="pk-caret" aria-hidden="true" />}
+    </div>
+  );
+}

--- a/packages/pkfit-ui/src/Chip.jsx
+++ b/packages/pkfit-ui/src/Chip.jsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+/**
+ * Chip — single quick-reply button with the ATLAS pill treatment.
+ *
+ * Props:
+ *   label       Required. Visible text.
+ *   ghost       If true, applies the muted "ghost" variant (used for skip-style options).
+ *   disabled    Disable interaction (caller typically toggles after a pick).
+ *   onClick     Click handler.
+ */
+export function Chip({ label, ghost = false, disabled = false, onClick }) {
+  return (
+    <button
+      type="button"
+      className={`pk-chip ${ghost ? 'pk-chip--ghost' : ''}`}
+      disabled={disabled}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  );
+}
+
+/**
+ * Chips — convenience wrapper that lays out multiple Chip children with the
+ * ATLAS gap. Mirrors the `chipsEl(options, onPick)` builder in the HTML.
+ *
+ * Props:
+ *   options     Array of { label, value? } passed to onPick when chosen.
+ *   ghostLast   If true, the last chip renders as ghost.
+ *   disabled    Disable the entire row.
+ *   onPick      Called with the chosen option.
+ *   children    Alternative to options — render Chip elements yourself.
+ */
+export function Chips({ options, ghostLast = false, disabled = false, onPick, children }) {
+  if (children) {
+    return <div className="pk-chips">{children}</div>;
+  }
+  return (
+    <div className="pk-chips">
+      {(options ?? []).map((opt, idx) => (
+        <Chip
+          key={opt.value ?? opt.label ?? idx}
+          label={opt.label}
+          ghost={ghostLast && idx === options.length - 1}
+          disabled={disabled}
+          onClick={() => onPick && onPick(opt)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/packages/pkfit-ui/src/ComposerWrap.jsx
+++ b/packages/pkfit-ui/src/ComposerWrap.jsx
@@ -1,0 +1,78 @@
+import React, { useState, useRef, useEffect } from 'react';
+
+/**
+ * ComposerWrap — fixed-bottom input row with the ATLAS pill composer and
+ * round send button. Mirrors the `<div class="composer-wrap">` markup in
+ * intake/checkin and `setComposer(mode, ...)` behavior.
+ *
+ * Props:
+ *   placeholder    Input placeholder. Defaults to 'Type here…'.
+ *   disabled       If true, locks the input + send (matches mode='locked').
+ *   autoFocus      Focus the input on mount / when re-enabled.
+ *   onSubmit       Called with the trimmed input value when send is pressed
+ *                  (or Enter inside the input). Caller is responsible for clearing.
+ *   value          Optional controlled value.
+ *   onChange       Optional controlled-value handler.
+ */
+export function ComposerWrap({
+  placeholder = 'Type here…',
+  disabled = false,
+  autoFocus = false,
+  onSubmit,
+  value: controlledValue,
+  onChange,
+}) {
+  const [internalValue, setInternalValue] = useState('');
+  const inputRef = useRef(null);
+  const isControlled = controlledValue !== undefined;
+  const value = isControlled ? controlledValue : internalValue;
+
+  useEffect(() => {
+    if (!disabled && autoFocus && inputRef.current) {
+      inputRef.current.focus();
+    }
+  }, [disabled, autoFocus]);
+
+  const setValue = (v) => {
+    if (!isControlled) setInternalValue(v);
+    onChange && onChange(v);
+  };
+
+  const send = () => {
+    const trimmed = (value || '').trim();
+    if (!trimmed || disabled) return;
+    onSubmit && onSubmit(trimmed);
+    if (!isControlled) setInternalValue('');
+  };
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    send();
+  };
+
+  return (
+    <div className="pk-composer-wrap">
+      <form className="pk-composer" autoComplete="off" onSubmit={handleSubmit}>
+        <input
+          ref={inputRef}
+          type="text"
+          placeholder={placeholder}
+          aria-label="Message"
+          disabled={disabled}
+          value={value}
+          onChange={(e) => setValue(e.target.value)}
+        />
+        <button
+          type="submit"
+          className="pk-send-btn"
+          aria-label="Send"
+          disabled={disabled || !value || !value.trim()}
+        >
+          <svg viewBox="0 0 16 16" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M3 8h10M9 4l4 4-4 4" />
+          </svg>
+        </button>
+      </form>
+    </div>
+  );
+}

--- a/packages/pkfit-ui/src/CtaCard.jsx
+++ b/packages/pkfit-ui/src/CtaCard.jsx
@@ -1,0 +1,44 @@
+import React, { useState } from 'react';
+
+/**
+ * CtaCard — soft cross-sell card with two pill buttons (yes / no).
+ * After either is clicked the card fades and disables itself, matching
+ * the HTML behavior (card.style.opacity='0.55'; buttons disabled).
+ *
+ * Props:
+ *   text       Required. Body copy.
+ *   yesLabel   Label for the primary action.
+ *   noLabel    Label for the ghost/dismiss action.
+ *   onYes      Called when the primary is clicked.
+ *   onNo       Called when the ghost is clicked.
+ */
+export function CtaCard({ text, yesLabel, noLabel, onYes, onNo }) {
+  const [picked, setPicked] = useState(false);
+  const pick = (cb) => () => {
+    setPicked(true);
+    cb && cb();
+  };
+  return (
+    <div className="pk-cta-card" style={picked ? { opacity: 0.55 } : undefined}>
+      <div className="pk-cta-text">{text}</div>
+      <div className="pk-cta-actions">
+        <button
+          type="button"
+          className="pk-cta-btn"
+          disabled={picked}
+          onClick={pick(onYes)}
+        >
+          {yesLabel}
+        </button>
+        <button
+          type="button"
+          className="pk-cta-btn pk-cta-btn--ghost"
+          disabled={picked}
+          onClick={pick(onNo)}
+        >
+          {noLabel}
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/pkfit-ui/src/EmailCard.jsx
+++ b/packages/pkfit-ui/src/EmailCard.jsx
@@ -1,0 +1,73 @@
+import React, { useState, useRef } from 'react';
+
+/**
+ * EmailCard — input card with validation, used by intake's `emailCard()`.
+ * Validation matches the original: length > 3, contains '@', contains '.'.
+ *
+ * Props:
+ *   label         Eyebrow. Defaults to 'Email address'.
+ *   placeholder   Defaults to 'you@example.com'.
+ *   submitLabel   Defaults to 'Continue'.
+ *   errorMessage  Error copy. Defaults to 'Needs to be a valid email address.'.
+ *   onSubmit      Called with the validated email string.
+ */
+export function EmailCard({
+  label = 'Email address',
+  placeholder = 'you@example.com',
+  submitLabel = 'Continue',
+  errorMessage = 'Needs to be a valid email address.',
+  onSubmit,
+}) {
+  const [value, setValue] = useState('');
+  const [error, setError] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const inputRef = useRef(null);
+
+  const trySubmit = () => {
+    if (submitted) return;
+    const v = value.trim();
+    const valid = v.length > 3 && v.includes('@') && v.includes('.');
+    if (!valid) {
+      setError(true);
+      inputRef.current && inputRef.current.focus();
+      return;
+    }
+    setError(false);
+    setSubmitted(true);
+    onSubmit && onSubmit(v);
+  };
+
+  const onKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      trySubmit();
+    }
+  };
+
+  return (
+    <div className="pk-input-card" style={submitted ? { opacity: 0.55 } : undefined}>
+      <div className="pk-field-label">{label}</div>
+      <input
+        ref={inputRef}
+        type="email"
+        autoComplete="email"
+        placeholder={placeholder}
+        value={value}
+        disabled={submitted}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={onKeyDown}
+      />
+      <div className={`pk-field-err ${error ? 'pk-field-err--visible' : ''}`}>
+        {errorMessage}
+      </div>
+      <button
+        type="button"
+        className="pk-submit-btn"
+        disabled={submitted}
+        onClick={trySubmit}
+      >
+        {submitLabel}
+      </button>
+    </div>
+  );
+}

--- a/packages/pkfit-ui/src/NextStepCard.jsx
+++ b/packages/pkfit-ui/src/NextStepCard.jsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+/**
+ * NextStepCard — italic-serif cue card. Used at end of intake flow to point
+ * the user at what's next without pressuring an action.
+ *
+ * Props:
+ *   label    Optional eyebrow label. Defaults to 'Next step'.
+ *   cue      Required body text — rendered in italic Fraunces.
+ */
+export function NextStepCard({ label = 'Next step', cue }) {
+  return (
+    <div className="pk-next-step-card">
+      <div className="pk-ns-label">{label}</div>
+      <div className="pk-ns-cue">{cue}</div>
+    </div>
+  );
+}

--- a/packages/pkfit-ui/src/SliderCard.jsx
+++ b/packages/pkfit-ui/src/SliderCard.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+
+/**
+ * SliderCard — 1–10 (configurable) range input with live readout. Mirrors
+ * `sliderCard()` in pkfit-checkin (used for energy / sleep / soreness severity).
+ *
+ * Props:
+ *   label         Required. Card eyebrow.
+ *   min           Range minimum. Default 1.
+ *   max           Range maximum. Default 10.
+ *   defaultValue  Initial value. Default 7.
+ *   submitLabel   Submit button copy. Default 'Lock it in'.
+ *   sideLabel     The small label to the left of the value (intake uses 'Lower').
+ *   onSubmit      Called with the chosen integer when submit is pressed.
+ */
+export function SliderCard({
+  label,
+  min = 1,
+  max = 10,
+  defaultValue = 7,
+  submitLabel = 'Lock it in',
+  sideLabel = 'Lower',
+  onSubmit,
+}) {
+  const [value, setValue] = useState(defaultValue);
+  const [submitted, setSubmitted] = useState(false);
+
+  const handleSubmit = () => {
+    if (submitted) return;
+    setSubmitted(true);
+    onSubmit && onSubmit(value);
+  };
+
+  return (
+    <div className="pk-card pk-slider" style={submitted ? { opacity: 0.55 } : undefined}>
+      <div className="pk-card-label">{label}</div>
+      <div className="pk-slider-head">
+        <span className="pk-slider-label">{sideLabel}</span>
+        <span className="pk-slider-value">{value}</span>
+      </div>
+      <input
+        type="range"
+        min={min}
+        max={max}
+        value={value}
+        disabled={submitted}
+        onChange={(e) => setValue(parseInt(e.target.value, 10))}
+      />
+      <div className="pk-slider-ticks">
+        <span>{min}</span>
+        <span>{max}</span>
+      </div>
+      <button
+        type="button"
+        className="pk-submit-btn"
+        disabled={submitted}
+        onClick={handleSubmit}
+      >
+        {submitLabel}
+      </button>
+    </div>
+  );
+}

--- a/packages/pkfit-ui/src/StreakCard.jsx
+++ b/packages/pkfit-ui/src/StreakCard.jsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+/**
+ * StreakCard — large serif number + "Week N, unbroken" label, optional cue.
+ * Mirrors `streakCard(streakN, cueText)` in pkfit-checkin.
+ *
+ * Props:
+ *   streak    Required. Week number — rendered as the large serif numeral.
+ *   label     Optional eyebrow. Defaults to `Week {streak}, unbroken`.
+ *   cue       Optional italic line under the rule.
+ */
+export function StreakCard({ streak, label, cue }) {
+  const labelText = label ?? `Week ${streak}, unbroken`;
+  return (
+    <div className="pk-streak-card">
+      <div>
+        <div className="pk-streak-num">{streak}</div>
+      </div>
+      <div className="pk-streak-body">
+        <div className="pk-streak-label">{labelText}</div>
+        {cue && <div className="pk-streak-cue">{cue}</div>}
+      </div>
+    </div>
+  );
+}

--- a/packages/pkfit-ui/src/Turn.jsx
+++ b/packages/pkfit-ui/src/Turn.jsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+/**
+ * Turn — wraps a single message turn (agent or client) with the ATLAS meta-row
+ * and animated entry. Mirrors the `addTurn` DOM builder in the intake/checkin HTML.
+ *
+ * Props:
+ *   role       'agent' | 'client'
+ *   who        Display label in the meta row (e.g. 'PK', 'Coach', 'You'). Required.
+ *   timestamp  Optional preformatted timestamp string. Falls back to current local time.
+ *   children   The bubble content (or any extra elements appended after).
+ */
+export function Turn({ role = 'agent', who, timestamp, children }) {
+  const isAgent = role === 'agent';
+  const ts = timestamp ?? defaultTimestamp();
+  return (
+    <div className={`pk-turn ${isAgent ? 'pk-turn--agent' : 'pk-turn--client'}`}>
+      <div className="pk-meta-row">
+        <span className={`pk-who ${isAgent ? 'pk-who--moon' : ''}`}>{who}</span>
+        {ts && <span>{ts}</span>}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function defaultTimestamp() {
+  const d = new Date();
+  return d.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }).toUpperCase();
+}

--- a/packages/pkfit-ui/src/index.js
+++ b/packages/pkfit-ui/src/index.js
@@ -1,0 +1,16 @@
+/**
+ * @pkfit/ui — canonical React components for the PKFIT ATLAS chat-UI pattern.
+ *
+ * Consumers must also import the tokens stylesheet once (e.g. in main.jsx):
+ *   import '@pkfit/ui/tokens.css';
+ */
+
+export { Turn } from './Turn.jsx';
+export { Bubble } from './Bubble.jsx';
+export { Chip, Chips } from './Chip.jsx';
+export { SliderCard } from './SliderCard.jsx';
+export { StreakCard } from './StreakCard.jsx';
+export { CtaCard } from './CtaCard.jsx';
+export { ComposerWrap } from './ComposerWrap.jsx';
+export { EmailCard } from './EmailCard.jsx';
+export { NextStepCard } from './NextStepCard.jsx';

--- a/packages/pkfit-ui/src/tokens.css
+++ b/packages/pkfit-ui/src/tokens.css
@@ -1,0 +1,402 @@
+/* ------------------------------------------------------------------
+   @pkfit/ui — ATLAS canon tokens + shared component CSS
+   Mirror of the pattern in pkfit-intake/public/index.html and
+   pkfit-checkin/public/index.html. Single source of truth.
+   ATLAS reference: ~/Desktop/ATLAS.md §3 (tokens), §5 (grid), §12 (axiom credit)
+   ------------------------------------------------------------------ */
+
+:root {
+  --field: #0F1318;
+  --deep: #0A0D12;
+  --surface: #1B2028;
+  --surface-up: #23292F;
+  --cream: #F5F1E8;
+  --cream-dim: rgba(245, 241, 232, 0.72);
+  --cream-ghost: rgba(245, 241, 232, 0.40);
+  --cream-muted: rgba(245, 241, 232, 0.55);
+  --moon: #A5B0BD;
+  --moon-dim: #7F8A98;
+  --moon-bright: #BFC9D3;
+  --grid: rgba(245, 241, 232, 0.035);
+  --notch: rgba(245, 241, 232, 0.12);
+  --rule: rgba(245, 241, 232, 0.08);
+  --radius: 12px;
+  --radius-lg: 14px;
+  --serif: 'Fraunces', Georgia, serif;
+  --sans: 'Space Grotesk', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --mono: 'JetBrains Mono', ui-monospace, monospace;
+}
+
+/* Animations ------------------------------------------------------ */
+@keyframes pkfit-fadeUp {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+@keyframes pkfit-cardIn {
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes pkfit-blink { 50% { opacity: 0; } }
+@keyframes pkfit-typing {
+  0%, 60%, 100% { opacity: 0.3; transform: translateY(0); }
+  30%           { opacity: 1; transform: translateY(-3px); }
+}
+
+/* Turn / Bubble --------------------------------------------------- */
+.pk-turn {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 100%;
+  animation: pkfit-fadeUp 0.42s cubic-bezier(.2,.7,.2,1);
+}
+.pk-turn.pk-turn--client { align-self: flex-end; align-items: flex-end; max-width: 86%; }
+.pk-turn.pk-turn--agent  { align-self: flex-start; width: 100%; }
+
+.pk-meta-row {
+  display: flex; align-items: center; gap: 8px;
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  color: var(--cream-muted);
+}
+.pk-meta-row .pk-who--moon { color: var(--moon); }
+
+.pk-bubble {
+  font-family: var(--sans);
+  font-size: 16px;
+  line-height: 1.55;
+  color: var(--cream);
+  white-space: pre-wrap;
+  word-wrap: break-word;
+}
+.pk-turn--client .pk-bubble {
+  background: var(--surface-up);
+  padding: 10px 16px;
+  border-radius: 18px 18px 4px 18px;
+  border: 1px solid var(--rule);
+  font-size: 15px;
+}
+.pk-turn--agent .pk-bubble { max-width: 560px; }
+
+.pk-caret {
+  display: inline-block;
+  width: 8px; height: 1.05em;
+  background: var(--moon);
+  vertical-align: -2px;
+  margin-left: 2px;
+  animation: pkfit-blink 0.9s steps(1) infinite;
+  border-radius: 1px;
+}
+
+.pk-typing { display: inline-flex; gap: 4px; align-items: center; padding: 6px 0; }
+.pk-typing span {
+  width: 6px; height: 6px; border-radius: 50%;
+  background: var(--cream-muted);
+  animation: pkfit-typing 1.4s ease-in-out infinite;
+}
+.pk-typing span:nth-child(2) { animation-delay: 0.16s; }
+.pk-typing span:nth-child(3) { animation-delay: 0.32s; }
+
+/* Generic card ---------------------------------------------------- */
+.pk-card {
+  margin-top: 4px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px 16px;
+  max-width: 560px;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: pkfit-cardIn 0.45s cubic-bezier(.2,.7,.2,1) forwards;
+  animation-delay: 0.06s;
+}
+.pk-card-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--cream-muted);
+  margin-bottom: 14px;
+}
+
+/* Chips ----------------------------------------------------------- */
+.pk-chips { display: flex; flex-wrap: wrap; gap: 8px; margin-top: 10px; }
+.pk-chip {
+  background: transparent;
+  border: 1px solid var(--rule);
+  color: var(--cream-dim);
+  font-family: var(--sans);
+  font-size: 13px;
+  letter-spacing: 0.005em;
+  padding: 8px 14px;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: border-color 0.18s ease, color 0.18s ease, background 0.18s ease;
+}
+.pk-chip:hover {
+  border-color: var(--moon);
+  color: var(--moon);
+  background: rgba(165, 176, 189, 0.04);
+}
+.pk-chip.pk-chip--ghost { color: var(--cream-muted); }
+.pk-chip:disabled { cursor: default; }
+
+/* Slider ---------------------------------------------------------- */
+.pk-slider-head {
+  display: flex; justify-content: space-between; align-items: baseline;
+  margin-bottom: 12px;
+}
+.pk-slider-head .pk-slider-label {
+  font-family: var(--sans); font-size: 14px; color: var(--cream); font-weight: 500;
+}
+.pk-slider-head .pk-slider-value {
+  font-family: var(--mono); font-size: 13px; color: var(--moon);
+}
+.pk-slider input[type=range] {
+  -webkit-appearance: none; appearance: none;
+  width: 100%; height: 4px;
+  background: var(--rule);
+  border-radius: 2px; outline: none; cursor: pointer;
+}
+.pk-slider input[type=range]::-webkit-slider-thumb {
+  -webkit-appearance: none; appearance: none;
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--moon); cursor: pointer;
+  border: 3px solid var(--surface);
+  box-shadow: 0 0 0 1px var(--moon);
+}
+.pk-slider input[type=range]::-moz-range-thumb {
+  width: 18px; height: 18px; border-radius: 50%;
+  background: var(--moon); cursor: pointer; border: 3px solid var(--surface);
+}
+.pk-slider-ticks {
+  display: flex; justify-content: space-between;
+  margin-top: 6px;
+  font-family: var(--mono); font-size: 10px; color: var(--cream-muted);
+  letter-spacing: 0.08em;
+}
+
+/* Submit button (shared by SliderCard + EmailCard) --------------- */
+.pk-submit-btn {
+  margin-top: 16px; width: 100%;
+  padding: 12px;
+  background: var(--moon);
+  color: var(--field);
+  border: none;
+  border-radius: 10px;
+  font-family: var(--sans);
+  font-weight: 600;
+  font-size: 14px;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: transform 0.12s ease, background 0.18s ease;
+}
+.pk-submit-btn:hover { background: var(--moon-bright); }
+.pk-submit-btn:active { transform: translateY(0); }
+.pk-submit-btn:disabled { opacity: 0.5; cursor: default; transform: none; }
+
+/* Streak card ----------------------------------------------------- */
+.pk-streak-card {
+  margin-top: 6px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px 16px;
+  max-width: 560px;
+  display: flex; align-items: baseline; gap: 16px;
+}
+.pk-streak-card .pk-streak-num {
+  font-family: var(--serif);
+  font-size: 44px;
+  font-weight: 500;
+  letter-spacing: -0.03em;
+  color: var(--moon);
+  line-height: 1;
+}
+.pk-streak-card .pk-streak-label {
+  font-family: var(--mono);
+  font-size: 11px;
+  color: var(--cream-dim);
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+  line-height: 1.5;
+}
+.pk-streak-card .pk-streak-cue {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 15px;
+  color: var(--cream);
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--rule);
+  line-height: 1.45;
+}
+.pk-streak-body { flex: 1; }
+
+/* Next-step card -------------------------------------------------- */
+.pk-next-step-card {
+  margin-top: 6px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-lg);
+  padding: 18px 20px 16px;
+  max-width: 560px;
+}
+.pk-next-step-card .pk-ns-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--cream-muted);
+  margin-bottom: 10px;
+}
+.pk-next-step-card .pk-ns-cue {
+  font-family: var(--serif);
+  font-style: italic;
+  font-size: 16px;
+  color: var(--cream);
+  line-height: 1.45;
+}
+
+/* CTA card -------------------------------------------------------- */
+.pk-cta-card {
+  margin-top: 6px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-lg);
+  padding: 16px 18px;
+  max-width: 560px;
+  display: flex; align-items: center; justify-content: space-between;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+.pk-cta-card .pk-cta-text {
+  font-family: var(--sans);
+  font-size: 14px;
+  color: var(--cream-dim);
+  flex: 1; min-width: 220px;
+}
+.pk-cta-card .pk-cta-actions { display: flex; gap: 8px; flex-shrink: 0; }
+.pk-cta-btn {
+  background: transparent;
+  border: 1px solid var(--moon-dim);
+  color: var(--moon);
+  padding: 7px 14px;
+  border-radius: 999px;
+  font-family: var(--sans);
+  font-size: 13px;
+  cursor: pointer;
+  transition: all 0.18s ease;
+}
+.pk-cta-btn:hover { border-color: var(--moon); background: rgba(165, 176, 189, 0.05); }
+.pk-cta-btn.pk-cta-btn--ghost { border-color: var(--rule); color: var(--cream-muted); }
+
+/* Email / Input card --------------------------------------------- */
+.pk-input-card {
+  margin-top: 4px;
+  background: var(--surface);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-lg);
+  padding: 16px 18px;
+  max-width: 560px;
+  opacity: 0;
+  transform: translateY(8px);
+  animation: pkfit-cardIn 0.45s cubic-bezier(.2,.7,.2,1) forwards;
+  animation-delay: 0.06s;
+}
+.pk-input-card .pk-field-label {
+  font-family: var(--mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  color: var(--cream-muted);
+  margin-bottom: 10px;
+}
+.pk-input-card input[type=text],
+.pk-input-card input[type=email] {
+  width: 100%;
+  background: var(--surface-up);
+  border: 1px solid var(--rule);
+  border-radius: 8px;
+  padding: 10px 14px;
+  font-family: var(--sans);
+  font-size: 15px;
+  color: var(--cream);
+  outline: none;
+  transition: border-color 0.18s ease;
+}
+.pk-input-card input:focus { border-color: var(--moon-dim); }
+.pk-input-card input::placeholder { color: var(--cream-muted); }
+.pk-input-card .pk-submit-btn {
+  margin-top: 10px;
+  padding: 10px;
+  border-radius: 8px;
+}
+.pk-input-card .pk-field-err {
+  margin-top: 6px;
+  font-family: var(--mono);
+  font-size: 11px;
+  color: #E79797;
+  letter-spacing: 0.04em;
+  display: none;
+}
+.pk-input-card .pk-field-err.pk-field-err--visible { display: block; }
+
+/* Composer -------------------------------------------------------- */
+.pk-composer-wrap {
+  position: absolute;
+  bottom: 0; left: 0; right: 0;
+  padding: 20px 28px 28px;
+  padding-bottom: max(28px, env(safe-area-inset-bottom));
+  display: flex; justify-content: center;
+  background: linear-gradient(180deg, rgba(15,19,24,0) 0%, rgba(15,19,24,0.92) 40%, var(--field) 100%);
+  pointer-events: none;
+  z-index: 5;
+}
+.pk-composer {
+  pointer-events: auto;
+  width: 100%;
+  max-width: 560px;
+  display: flex; align-items: center; gap: 10px;
+  background: var(--surface-up);
+  border: 1px solid var(--rule);
+  border-radius: 999px;
+  padding: 6px 6px 6px 20px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.pk-composer:focus-within {
+  border-color: var(--moon-dim);
+  box-shadow: 0 4px 28px rgba(0, 0, 0, 0.35);
+}
+.pk-composer input {
+  flex: 1;
+  background: transparent;
+  border: none; outline: none;
+  color: var(--cream);
+  font-family: var(--sans);
+  font-size: 15px;
+}
+.pk-composer input::placeholder { color: var(--cream-muted); }
+.pk-composer input:disabled { cursor: not-allowed; }
+.pk-send-btn {
+  width: 34px; height: 34px;
+  border-radius: 50%;
+  background: var(--moon);
+  color: var(--field);
+  border: none;
+  cursor: pointer;
+  display: flex; align-items: center; justify-content: center;
+  font-size: 15px;
+  transition: all 0.18s ease;
+  flex-shrink: 0;
+}
+.pk-send-btn:hover { background: var(--moon-bright); }
+.pk-send-btn:disabled { opacity: 0.4; cursor: default; background: var(--moon-dim); }
+.pk-send-btn svg { width: 16px; height: 16px; }
+
+/* Responsive ------------------------------------------------------ */
+@media (max-width: 640px) {
+  .pk-composer-wrap { padding: 16px 18px 22px; }
+  .pk-turn--agent .pk-bubble { font-size: 15px; }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -12,8 +12,17 @@ export default defineConfig({
       },
     },
   },
+  // Workspace package contains untranspiled JSX; let Vite handle it directly
+  // rather than pre-bundling it through esbuild's commonjs path.
+  optimizeDeps: {
+    exclude: ['@pkfit/ui'],
+  },
   build: {
     outDir: 'dist',
     sourcemap: false,
+    commonjsOptions: {
+      // Workspace package is ESM-only, skip CJS conversion attempts.
+      include: [/node_modules/],
+    },
   },
 });


### PR DESCRIPTION
## What changed

Introduces `packages/pkfit-ui/` — a workspace package that becomes the
canonical React source for the Stage 0.5 ATLAS chat-UI pattern
(`Turn`, `Bubble`, `Chip`/`Chips`, `SliderCard`, `StreakCard`, `CtaCard`,
`ComposerWrap`, `EmailCard`, `NextStepCard`) plus `tokens.css`. Wires
pkfit-app's root `package.json` for npm workspaces and adds `@pkfit/ui`
as a dependency. Vite is configured to serve the workspace package's
raw JSX directly (`optimizeDeps.exclude`).

## Why

Single source of truth for the chat surface used by intake, check-in,
and (eventually) the in-app coach experience. Prevents future drift —
when the ATLAS spec evolves, one package gets updated, not three.

## Acceptance criteria

- [x] Build passes (`npm run build`) — output below
- [x] No console errors on a fresh page load
- [x] Smoke-test: bundle hashes unchanged (zero delta — see below)
- [x] No untracked secrets committed
- [x] BUILT ON AXIOM credit intact on user-facing surfaces (no shipped UI changed)
- [x] Linked to GitHub Issue #17 (closes #17)

## Smoke-test output

```
$ npm run build
vite v5.4.21 building for production...
✓ 1678 modules transformed.
dist/index.html                   1.20 kB │ gzip:   0.51 kB
dist/assets/index-BZ1yNwbe.css   21.36 kB │ gzip:   5.00 kB
dist/assets/index-CUasjU3d.js   366.92 kB │ gzip: 101.97 kB
✓ built in 15.74s
```

Identical hashes vs. baseline (`app-main`): tree-shaking removes the
unused workspace package from production output until something imports
from it.

## Reviewer note — honest scope correction

The original Issue #17 framing assumed pkfit-app already had React copies
of these ATLAS components in `src/components/` to deduplicate. **Audit on
`app-main` confirms it does not.** The pattern only exists in two places:

- `~/Desktop/pkfit-intake-deploy/public/index.html` (vanilla HTML/CSS/JS)
- `~/Desktop/pkfit-checkin-deploy/public/index.html` (vanilla HTML/CSS/JS)

`pkfit-app/src/pages/client/Assistant.jsx` is the only chat-shaped surface
in pkfit-app today and uses Tailwind + the local `ui/Card`/`ui/Button` set
— a completely different visual treatment from ATLAS.

So this PR could not "delete duplicate copies in pkfit-app" (none existed)
and instead establishes the canonical React form so all three surfaces can
converge in follow-up PRs. See `packages/pkfit-ui/MIGRATION.md` for the
adoption path for each surface (intake, check-in, Assistant.jsx).

Hard guardrails honored:
- Did not touch `Assistant.jsx`, `pkfit-intake-deploy`, or `pkfit-checkin-deploy`
- Did not change visual behavior of any rendered component
- All work on `feature/ui-shared` off `app-main`
