### PR TITLE
feat(distribute): Buffer-based content distribution endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,8 @@ Server-only (set in the Netlify dashboard, never in client bundle):
 | `STRIPE_PRICE_IDENTITY_MONTHLY` / `_ANNUAL` | Identity Architecture tier price IDs |
 | `STRIPE_PRICE_FULL_MONTHLY` / `_ANNUAL` | Full Integration tier price IDs |
 | `STRIPE_PRICE_PREMIUM_MONTHLY` / `_ANNUAL` | Premium tier price IDs |
+| `BUFFER_ACCESS_TOKEN` | Single-tenant Bearer token for the Buffer GraphQL API. Used by `/api/distribute`. Generated at `https://publish.buffer.com/settings/api`. |
+| `SLACK_WEBHOOK_URL_AXIOM_DISTRIBUTOR` | Incoming webhook for `#axiom-distributor-alerts`. Receives WARN/CRITICAL alerts from the distributor. Optional — when unset, alerts log to console only. |
 
 ## Supabase setup
 

--- a/netlify/functions/_shared/canon-check.js
+++ b/netlify/functions/_shared/canon-check.js
@@ -1,0 +1,108 @@
+// Brand-canon check for distributor captions.
+//
+// Wraps Anthropic to score a caption against the PKFIT/AXIOM brand voice canon.
+// Returns { score: 0.0-1.0, violations: [string], suggestions: [string] }.
+//
+// Thresholds (used by the caller, distribute.js):
+//   score >= 0.90  → publish
+//   0.70 <= score < 0.90 → publish but flag (canon_flagged in response)
+//   score < 0.70   → reject with CANON_CHECK_FAILED
+//
+// PKFIT canon (Quiet Assassin): no emoji, no exclamation points, no hype
+// adjectives ("incredible", "amazing", "transform your life"). Mechanism over
+// motivation. The prompt below frames the rules so the model returns a
+// consistent score.
+//
+// On Anthropic failure this throws — the caller treats that as INTERNAL_ERROR
+// rather than a canon failure. A network blip should not cause a content
+// rejection; it should cause an explicit "we couldn't check" surfaced to ops.
+
+import { getAnthropic, MODEL } from './anthropic.js';
+
+const CANON_RULES = `
+You are a brand-canon validator for PKFIT (Percy Keith's fitness coaching brand)
+and AXIOM (Percy's positioning consultancy). Both brands share a "Quiet Assassin"
+voice with the following hard rules:
+
+HARD RULES (any violation drops the score below 0.70):
+- No emoji of any kind.
+- No exclamation points.
+- No hype adjectives ("incredible", "amazing", "life-changing", "game-changer",
+  "transform your life", "unstoppable", "unleash").
+- No fitness-bro cliches ("crush it", "beast mode", "no excuses", "grind").
+- No false urgency ("act now", "limited time", "don't miss out").
+
+SOFT RULES (each violation drops the score by ~0.05):
+- Mechanism over motivation: explain the WHY, not the FEELING.
+- Specific over vague: "deadlift bar path drifts forward at lockout" beats
+  "improve your deadlift form".
+- Diagnose → Program → Lock framing where applicable (DPL).
+- Sentence cadence: short clauses, no rhetorical questions stacked.
+
+Score scale:
+  1.00 = perfect canon adherence
+  0.90 = on-canon, minor stylistic drift
+  0.70 = publishable but soft; one or two soft-rule violations
+  0.50 = noticeable canon drift; multiple soft-rule violations or one near-hard
+  0.00 = hard-rule violation, refuse to publish
+
+Return ONLY a JSON object on a single line:
+{"score": <float 0..1>, "violations": [<string>], "suggestions": [<string>]}
+
+Do not wrap the JSON in markdown fences. Do not add any prose before or after.
+`;
+
+export async function canonCheck({ caption, platform, content_pillar, canon_version }) {
+  const anthropic = getAnthropic();
+  const userMessage = JSON.stringify({
+    platform,
+    content_pillar,
+    canon_version,
+    caption,
+  });
+
+  const resp = await anthropic.messages.create({
+    model: MODEL,
+    max_tokens: 600,
+    system: CANON_RULES,
+    messages: [{ role: 'user', content: userMessage }],
+  });
+
+  const text = resp.content?.[0]?.text ?? '';
+  const parsed = parseCanonJson(text);
+  if (!parsed) {
+    throw new Error(`canon-check: unparseable model output: ${text.slice(0, 200)}`);
+  }
+
+  const score = clamp01(Number(parsed.score));
+  if (Number.isNaN(score)) {
+    throw new Error(`canon-check: missing or non-numeric score in: ${text.slice(0, 200)}`);
+  }
+
+  return {
+    score,
+    violations: Array.isArray(parsed.violations) ? parsed.violations.map(String) : [],
+    suggestions: Array.isArray(parsed.suggestions) ? parsed.suggestions.map(String) : [],
+  };
+}
+
+function parseCanonJson(text) {
+  try {
+    return JSON.parse(text);
+  } catch {
+    const match = text.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return null;
+    }
+  }
+}
+
+function clamp01(n) {
+  if (Number.isNaN(n)) return NaN;
+  if (n < 0) return 0;
+  if (n > 1) return 1;
+  return n;
+}

--- a/netlify/functions/_shared/slack.js
+++ b/netlify/functions/_shared/slack.js
@@ -1,0 +1,48 @@
+// Slack webhook helper for distributor alerts.
+//
+// Two severity levels per the distribute spec §5:
+//   - WARN     :warning:        single post failed (auth/platform/content)
+//   - CRITICAL :rotating_light: auth broken, or 5+ failures in 1h
+//
+// Webhook URL is read lazily from env so the module imports cleanly in tests
+// without any stub. If the webhook is unset we log to console and return —
+// alerting must NEVER fail the caller (the post may have already been
+// scheduled in Buffer; losing the alert is preferable to a 500).
+
+const WEBHOOK_ENV = 'SLACK_WEBHOOK_URL_AXIOM_DISTRIBUTOR';
+
+const PREFIX = {
+  WARN: ':warning:',
+  CRITICAL: ':rotating_light:',
+};
+
+export async function slackAlert(severity, message, extra = {}) {
+  const url = process.env[WEBHOOK_ENV];
+  const prefix = PREFIX[severity] ?? ':information_source:';
+  const text = `${prefix} *[${severity}]* ${message}`;
+
+  if (!url) {
+    // eslint-disable-next-line no-console
+    console.warn(`[slack] ${WEBHOOK_ENV} unset; would have posted: ${text}`);
+    return { posted: false, reason: 'webhook-unconfigured' };
+  }
+
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text, mrkdwn: true, ...extra }),
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      // eslint-disable-next-line no-console
+      console.error(`[slack] ${res.status}: ${body.slice(0, 200)}`);
+      return { posted: false, reason: `http-${res.status}` };
+    }
+    return { posted: true };
+  } catch (err) {
+    // eslint-disable-next-line no-console
+    console.error(`[slack] post failed: ${err?.message ?? err}`);
+    return { posted: false, reason: 'network-error' };
+  }
+}

--- a/netlify/functions/distribute.js
+++ b/netlify/functions/distribute.js
@@ -1,0 +1,460 @@
+// netlify/functions/distribute.js
+//
+// /api/distribute — the AXIOM Distributor's posting endpoint.
+//
+// Mirrors the existing /generate-image and /generate-meal-plan shape:
+//   - Auth-gated (Supabase JWT via requireUser)
+//   - Per-user rate-limited (rate_limits table; 30/min, 500/day buckets)
+//   - Server-side Buffer auth (BUFFER_ACCESS_TOKEN env, redacted from logs)
+//   - Optional Anthropic-powered brand-canon check pre-publish
+//   - Idempotent on (producer_task_id, buffer_channel_id) — 409 on conflict
+//
+// Spec: see PR description for the full integration spec doc path. Buffer's
+// public API is GraphQL, single-tenant Bearer-token auth, in beta. TikTok is
+// not in the supported-platforms list — TikTok-bound posts are forced to
+// `mode: draft` for manual publish from the Buffer app.
+
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { getAdminClient } from './_shared/supabase-admin.js';
+import { checkRateLimit } from './_shared/rate-limit.js';
+import { canonCheck } from './_shared/canon-check.js';
+import { slackAlert } from './_shared/slack.js';
+
+// Buffer GraphQL endpoint (verified 2026-04 per spec §1).
+const BUFFER_API_URL = 'https://api.buffer.com';
+
+// Per-platform constraints — source of truth for the pre-Buffer validator.
+// Caption/hashtag caps come from Buffer's docs (spec §2). If Buffer relaxes
+// these we relax here too; if they tighten, this rejects before burning a
+// Buffer rate-limit slot.
+const PLATFORM_LIMITS = {
+  instagram: { caption_max: 2200,  hashtag_max: 30 },
+  linkedin:  { caption_max: 3000,  hashtag_max: 30 },
+  youtube:   { caption_max: 5000,  hashtag_max: 15 },
+  twitter:   { caption_max: 4000,  hashtag_max: 30 },
+  threads:   { caption_max: 500,   hashtag_max: 30 },
+  facebook:  { caption_max: 63206, hashtag_max: 30 },
+  pinterest: { caption_max: 500,   hashtag_max: 20 },
+  bluesky:   { caption_max: 300,   hashtag_max: 30 },
+  // tiktok is allowed but not in PLATFORM_LIMITS — see TIKTOK_DRAFT_MODE.
+};
+
+const TIKTOK_DRAFT_MODE = true;
+const CANON_THRESHOLD_HARD = 0.70;
+const CANON_THRESHOLD_SOFT = 0.90;
+
+const RATE_LIMIT_PER_MIN = 30;
+const RATE_LIMIT_PER_DAY = 500;
+
+const ERR = {
+  INVALID_AUTH: 'INVALID_AUTH',
+  RATE_LIMITED: 'RATE_LIMITED',
+  INVALID_PAYLOAD: 'INVALID_PAYLOAD',
+  MEDIA_UNREACHABLE: 'MEDIA_UNREACHABLE',
+  CANON_CHECK_FAILED: 'CANON_CHECK_FAILED',
+  PLATFORM_NOT_SUPPORTED: 'PLATFORM_NOT_SUPPORTED',
+  DUPLICATE_DISTRIBUTION: 'DUPLICATE_DISTRIBUTION',
+  BUFFER_API_ERROR: 'BUFFER_API_ERROR',
+  BUFFER_AUTH_ERROR: 'BUFFER_AUTH_ERROR',
+  BUFFER_RATE_LIMITED: 'BUFFER_RATE_LIMITED',
+  INTERNAL_ERROR: 'INTERNAL_ERROR',
+};
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  let user;
+  try {
+    ({ user } = await requireUser(event));
+  } catch (e) {
+    return errorResponse(e);
+  }
+
+  // Two-bucket per-user rate limit. Both buckets must allow.
+  const rlMin = await checkRateLimit({
+    userId: user.id, bucket: 'distribute-min', max: RATE_LIMIT_PER_MIN, windowSec: 60,
+  });
+  if (!rlMin.allowed) return rateLimitedResponse(rlMin.retryAfterSec);
+  const rlDay = await checkRateLimit({
+    userId: user.id, bucket: 'distribute-day', max: RATE_LIMIT_PER_DAY, windowSec: 86400,
+  });
+  if (!rlDay.allowed) return rateLimitedResponse(rlDay.retryAfterSec);
+
+  let payload;
+  try {
+    payload = JSON.parse(event.body || '{}');
+  } catch {
+    return jsonError(400, ERR.INVALID_PAYLOAD, 'Body is not valid JSON');
+  }
+
+  const validation = validatePayload(payload);
+  if (!validation.ok) {
+    return jsonError(400, ERR.INVALID_PAYLOAD, validation.error);
+  }
+
+  const {
+    platform,
+    channel_id,
+    content_type,
+    media_urls,
+    thumbnail_url,
+    caption,
+    schedule_mode,
+    schedule_at,
+    metadata,
+    skip_canon_check,
+  } = payload;
+
+  if (!PLATFORM_LIMITS[platform] && platform !== 'tiktok') {
+    return jsonError(400, ERR.PLATFORM_NOT_SUPPORTED, `Platform ${platform} is not supported`);
+  }
+
+  const constraintCheck = checkPlatformConstraints(platform, caption);
+  if (!constraintCheck.ok) {
+    return jsonError(400, ERR.INVALID_PAYLOAD, constraintCheck.error);
+  }
+
+  // Fail-fast on missing Buffer token. We check here (not at module load) so
+  // the test environment can import the function without stubbing the env.
+  const bufferToken = process.env.BUFFER_ACCESS_TOKEN;
+  if (!bufferToken) {
+    return jsonResponse(500, { error: 'BUFFER_ACCESS_TOKEN missing' });
+  }
+
+  const admin = getAdminClient();
+
+  // Idempotency check — same producer task to same channel returns the
+  // existing row instead of double-posting.
+  const { data: existing } = await admin
+    .from('distributed_posts')
+    .select('id, buffer_post_id, scheduled_at, buffer_status')
+    .eq('producer_task_id', metadata.producer_task_id)
+    .eq('buffer_channel_id', channel_id)
+    .maybeSingle();
+
+  if (existing) {
+    return jsonError(409, ERR.DUPLICATE_DISTRIBUTION, 'This task was already distributed to this channel', {
+      existing_post_id: existing.buffer_post_id,
+      scheduled_at: existing.scheduled_at,
+      buffer_status: existing.buffer_status,
+    });
+  }
+
+  // Media reachability — Buffer fetches the URL at publish time, which can be
+  // hours/days after we schedule. A 404 here is much better than a Bucket-D
+  // error after the fact.
+  if (Array.isArray(media_urls)) {
+    for (const url of media_urls) {
+      const reachable = await checkUrlReachable(url);
+      if (!reachable) {
+        return jsonError(400, ERR.MEDIA_UNREACHABLE, `Media URL not reachable: ${url}`);
+      }
+    }
+  }
+
+  // Brand-canon gate. skip_canon_check is for Producer agents that already
+  // ran the same check before handing off — never set by the Distributor
+  // agent itself (see system prompt in spec §9).
+  let canonResult = { score: 1.0, violations: [], suggestions: [] };
+  if (!skip_canon_check) {
+    try {
+      canonResult = await canonCheck({
+        caption,
+        platform,
+        content_pillar: metadata.content_pillar,
+        canon_version: metadata.canon_version,
+      });
+    } catch (e) {
+      // Anthropic outage / parse failure — surface, do not silently publish.
+      return jsonError(500, ERR.INTERNAL_ERROR, `Canon check failed: ${e.message}`);
+    }
+
+    if (canonResult.score < CANON_THRESHOLD_HARD) {
+      return jsonError(422, ERR.CANON_CHECK_FAILED,
+        `Caption scored ${canonResult.score.toFixed(2)}, below hard threshold ${CANON_THRESHOLD_HARD}`,
+        {
+          canon_score: canonResult.score,
+          violations: canonResult.violations,
+          suggestions: canonResult.suggestions,
+        });
+    }
+  }
+
+  // TikTok forces draft mode (spec §10) — Buffer's GraphQL surface doesn't
+  // publish to TikTok, but draft creation lands the asset in the Buffer app
+  // for Percy to one-tap publish.
+  const effectiveMode = (platform === 'tiktok' && TIKTOK_DRAFT_MODE)
+    ? 'draft'
+    : schedule_mode;
+
+  const bufferInput = buildCreatePostInput({
+    text: caption,
+    channel_id,
+    schedule_mode: effectiveMode,
+    schedule_at,
+    media_urls,
+    thumbnail_url,
+    content_type,
+  });
+
+  let bufferResult;
+  try {
+    bufferResult = await callBufferCreatePost(bufferInput, bufferToken);
+  } catch (e) {
+    await slackAlert('WARN',
+      `Buffer API call failed for task ${metadata.producer_task_id} on ${platform}: ${e.message}`);
+    return jsonError(502, ERR.BUFFER_API_ERROR, 'Buffer API request failed', { retry_safe: true });
+  }
+
+  // GraphQL transport-level errors
+  if (bufferResult.errors?.length) {
+    const err = bufferResult.errors[0];
+    if (err.extensions?.code === 'RATE_LIMIT_EXCEEDED') {
+      return jsonError(429, ERR.BUFFER_RATE_LIMITED, err.message ?? 'Buffer rate limit', {
+        retryAfter: err.extensions.retryAfter,
+      });
+    }
+    const msg = err.message ?? '';
+    if (msg.toLowerCase().includes('unauthorized') || msg.toLowerCase().includes('auth')) {
+      await slackAlert('CRITICAL', 'Buffer API auth failed — check BUFFER_ACCESS_TOKEN');
+      return jsonError(401, ERR.BUFFER_AUTH_ERROR, 'Buffer rejected our credentials');
+    }
+    return jsonError(502, ERR.BUFFER_API_ERROR, msg || 'Buffer API error');
+  }
+
+  // GraphQL response is a union: PostActionSuccess | MutationError.
+  // MutationError surfaces as a typename + message on the same field.
+  const result = bufferResult.data?.createPost;
+  if (!result || (result.message && !result.post)) {
+    const message = result?.message ?? 'Unknown Buffer error';
+    await slackAlert('WARN',
+      `Buffer rejected post for task ${metadata.producer_task_id} on ${platform}: ${message}`);
+    return jsonError(422, ERR.BUFFER_API_ERROR, message);
+  }
+
+  const post = result.post;
+
+  // Persist the Observer-correlation row. If this insert fails after Buffer
+  // accepted the post, we have a real-but-unrecorded post in Buffer — alert
+  // CRITICAL but don't fail the request (the post is real and scheduled).
+  let rowId;
+  try {
+    const { data: row, error: insertError } = await admin
+      .from('distributed_posts')
+      .insert({
+        buffer_post_id: post.id,
+        buffer_channel_id: channel_id,
+        platform,
+        scheduled_at: post.dueAt ?? schedule_at ?? null,
+        buffer_status: effectiveMode === 'draft' ? 'draft' : 'scheduled',
+        producer_task_id: metadata.producer_task_id,
+        source_asset_id: metadata.source_asset_id ?? null,
+        canon_version: metadata.canon_version,
+        content_pillar: metadata.content_pillar,
+        generation_model: metadata.generation_model ?? null,
+        generation_prompt_hash: metadata.generation_prompt_hash ?? null,
+        caption_canon_score: canonResult.score,
+        distributor_agent_version: metadata.distributor_agent_version ?? null,
+        metadata_json: metadata,
+      })
+      .select('id')
+      .single();
+
+    if (insertError) {
+      await slackAlert('CRITICAL',
+        `Posted to Buffer (id=${post.id}) but failed to record in distributed_posts: ${insertError.message}`);
+    } else {
+      rowId = row?.id;
+    }
+  } catch (e) {
+    await slackAlert('CRITICAL',
+      `Posted to Buffer (id=${post.id}) but exception recording row: ${e.message}`);
+  }
+
+  const flagged = !skip_canon_check && canonResult.score < CANON_THRESHOLD_SOFT;
+
+  return jsonResponse(200, {
+    ok: true,
+    post_id: post.id,
+    scheduled_at: post.dueAt ?? schedule_at ?? null,
+    status: effectiveMode === 'draft' ? 'draft' : 'scheduled',
+    canon_score: canonResult.score,
+    canon_flagged: flagged,
+    canon_violations: flagged ? canonResult.violations : undefined,
+    distributed_post_row_id: rowId,
+    note: platform === 'tiktok'
+      ? 'TikTok routes via Buffer drafts; manual publish required from Buffer app'
+      : undefined,
+  });
+};
+
+// ─── Buffer call ──────────────────────────────────────────────────────────────
+
+const CREATE_POST_MUTATION = `
+  mutation CreatePost($input: CreatePostInput!) {
+    createPost(input: $input) {
+      ... on PostActionSuccess {
+        post {
+          id
+          text
+          dueAt
+          channelId
+          assets { id mimeType source }
+        }
+      }
+      ... on MutationError { message }
+    }
+  }
+`;
+
+async function callBufferCreatePost(input, token) {
+  const res = await fetch(BUFFER_API_URL, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${token}`,
+    },
+    body: JSON.stringify({ query: CREATE_POST_MUTATION, variables: { input } }),
+  });
+  // Surface non-2xx as a thrown error so the handler treats it as transient.
+  // GraphQL errors come back as 200 with an `errors` array; those are handled
+  // in the success branch.
+  if (!res.ok && res.status >= 500) {
+    throw new Error(`Buffer ${res.status}: ${(await res.text()).slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+// ─── Input shaping ────────────────────────────────────────────────────────────
+
+function buildCreatePostInput({ text, channel_id, schedule_mode, schedule_at, media_urls, thumbnail_url, content_type }) {
+  const input = {
+    text,
+    channelId: channel_id,
+    schedulingType: 'automatic',
+    mode: schedule_mode,
+  };
+
+  if (schedule_mode === 'customScheduled') {
+    input.dueAt = schedule_at;
+  }
+
+  if (content_type === 'image' && media_urls?.length) {
+    input.assets = { images: media_urls.map((url) => ({ url })) };
+  } else if (content_type === 'video' && media_urls?.length) {
+    input.assets = {
+      videos: media_urls.map((url) => ({
+        url,
+        ...(thumbnail_url ? { thumbnailUrl: thumbnail_url } : {}),
+      })),
+    };
+  } else if (content_type === 'carousel' && media_urls?.length) {
+    input.assets = { images: media_urls.map((url) => ({ url })) };
+  }
+
+  return input;
+}
+
+// ─── Validators ───────────────────────────────────────────────────────────────
+
+function validatePayload(p) {
+  if (!p || typeof p !== 'object') return { ok: false, error: 'Body must be an object' };
+  if (!p.platform) return { ok: false, error: 'platform required' };
+  if (!p.channel_id) return { ok: false, error: 'channel_id required' };
+  if (!p.content_type) return { ok: false, error: 'content_type required' };
+  if (!['text', 'image', 'video', 'carousel'].includes(p.content_type)) {
+    return { ok: false, error: 'content_type must be text|image|video|carousel' };
+  }
+  if (p.content_type !== 'text' && (!Array.isArray(p.media_urls) || p.media_urls.length === 0)) {
+    return { ok: false, error: 'media_urls required for non-text content' };
+  }
+  if (typeof p.caption !== 'string') return { ok: false, error: 'caption required (use empty string for none)' };
+  if (!['addToQueue', 'customScheduled', 'draft'].includes(p.schedule_mode)) {
+    return { ok: false, error: 'schedule_mode must be addToQueue|customScheduled|draft' };
+  }
+  if (p.schedule_mode === 'customScheduled' && !p.schedule_at) {
+    return { ok: false, error: 'schedule_at required for customScheduled mode' };
+  }
+  if (p.schedule_at) {
+    const t = Date.parse(p.schedule_at);
+    if (Number.isNaN(t)) return { ok: false, error: 'schedule_at must be ISO 8601 datetime' };
+    if (t <= Date.now()) return { ok: false, error: 'schedule_at must be in the future' };
+  }
+  if (!p.metadata?.producer_task_id) return { ok: false, error: 'metadata.producer_task_id required' };
+  if (!p.metadata?.canon_version) return { ok: false, error: 'metadata.canon_version required' };
+  if (!p.metadata?.content_pillar) return { ok: false, error: 'metadata.content_pillar required' };
+  return { ok: true };
+}
+
+function checkPlatformConstraints(platform, caption) {
+  const limits = PLATFORM_LIMITS[platform];
+  if (!limits) return { ok: true };
+
+  if (caption.length > limits.caption_max) {
+    return {
+      ok: false,
+      error: `Caption exceeds ${platform} limit of ${limits.caption_max} chars (got ${caption.length})`,
+    };
+  }
+  const hashtagCount = (caption.match(/#\w+/g) ?? []).length;
+  if (hashtagCount > limits.hashtag_max) {
+    return {
+      ok: false,
+      error: `Caption has ${hashtagCount} hashtags, exceeds ${platform} max of ${limits.hashtag_max}`,
+    };
+  }
+  return { ok: true };
+}
+
+async function checkUrlReachable(url) {
+  try {
+    const res = await fetch(url, { method: 'HEAD', redirect: 'follow' });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+// ─── Response helpers ─────────────────────────────────────────────────────────
+
+function rateLimitedResponse(retryAfterSec) {
+  const retry = retryAfterSec ?? 60;
+  return {
+    statusCode: 429,
+    headers: { 'Content-Type': 'application/json', 'Retry-After': String(retry) },
+    body: JSON.stringify({
+      ok: false,
+      error_code: ERR.RATE_LIMITED,
+      error_message: `Rate limit. Wait ${retry}s.`,
+      retry_safe: true,
+      retryAfter: retry,
+    }),
+  };
+}
+
+function jsonError(statusCode, code, message, extra = {}) {
+  return {
+    statusCode,
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      ok: false,
+      error_code: code,
+      error_message: message,
+      retry_safe: statusCode >= 500 || code === ERR.RATE_LIMITED || code === ERR.BUFFER_RATE_LIMITED,
+      ...extra,
+    }),
+  };
+}
+
+// Exported for tests — the handler is the only public surface in production.
+export const __internals = {
+  validatePayload,
+  checkPlatformConstraints,
+  buildCreatePostInput,
+  PLATFORM_LIMITS,
+  CANON_THRESHOLD_HARD,
+  CANON_THRESHOLD_SOFT,
+  ERR,
+};

--- a/supabase/migrations/0025_distributed_posts.sql
+++ b/supabase/migrations/0025_distributed_posts.sql
@@ -1,0 +1,62 @@
+-- distributed_posts — external join table for the Buffer distributor.
+--
+-- Buffer's GraphQL Post type does not expose a customFields/metadata surface
+-- in the public schema (verified 2026-04, see distribute spec §4), so we keep
+-- our own row per scheduled post and join on buffer_post_id. This is the
+-- correlation surface the Observer agent uses to trace published-post
+-- performance back to the Producer task, canon version, and content pillar
+-- that produced it.
+--
+-- producer_task_id and source_asset_id are forward-references — the
+-- producer_tasks and assets tables don't exist yet (will land with the
+-- AXIOM Producer bench). Columns are typed `uuid` with no FK so this
+-- migration ships independently. When those tables arrive, a follow-up
+-- migration adds the constraints.
+--
+-- Server-only writes via service role; clients never touch this table.
+
+create table if not exists public.distributed_posts (
+  id                          uuid primary key default gen_random_uuid(),
+  created_at                  timestamptz not null default now(),
+
+  -- Buffer side
+  buffer_post_id              text not null unique,
+  buffer_channel_id           text not null,
+  platform                    text not null,
+  scheduled_at                timestamptz,
+  published_url               text,
+  buffer_status               text not null default 'scheduled',
+
+  -- Observer correlation surface
+  producer_task_id            uuid,
+  source_asset_id             uuid,
+  canon_version               text not null,
+  content_pillar              text not null,
+  generation_model            text,
+  generation_prompt_hash      text,
+  caption_canon_score         numeric(4,3),
+  distributor_agent_version   text,
+  metadata_json               jsonb not null default '{}'::jsonb,
+
+  -- Idempotency: the same producer task should never publish to the same
+  -- channel twice (see spec §10). The function returns 409 on conflict.
+  constraint distributed_posts_task_channel_unique
+    unique (producer_task_id, buffer_channel_id)
+);
+
+create index if not exists distributed_posts_producer_task_idx
+  on public.distributed_posts (producer_task_id);
+
+create index if not exists distributed_posts_pillar_idx
+  on public.distributed_posts (content_pillar);
+
+create index if not exists distributed_posts_canon_idx
+  on public.distributed_posts (canon_version);
+
+create index if not exists distributed_posts_status_scheduled_idx
+  on public.distributed_posts (buffer_status, scheduled_at);
+
+alter table public.distributed_posts enable row level security;
+-- No policies: only the server (service role) reads/writes. RLS still on
+-- so a misconfigured anon-key request gets a deterministic permission denied
+-- rather than reading the full table.

--- a/tests/functions/distribute.test.js
+++ b/tests/functions/distribute.test.js
@@ -1,0 +1,482 @@
+// Tests for netlify/functions/distribute.js
+//
+// Covers the gates the spec calls out as critical:
+//   - Auth gate (401 on missing/invalid JWT)
+//   - Rate limit (429 when per-minute bucket exhausted)
+//   - Canon check fail-closed at 0.70
+//   - Canon soft-flag between 0.70 and 0.90 (publishes, surfaces canon_flagged)
+//   - schedule_at validation (past time, non-ISO)
+//   - Buffer transient error → 502 with retry_safe + Slack WARN
+//   - Buffer auth error → 401 + Slack CRITICAL
+//   - Idempotency (409 on (producer_task_id, channel_id) match)
+//   - TikTok routing → draft mode regardless of caller's schedule_mode
+//   - Happy path with happy-path Buffer GraphQL response
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { createSupabaseMock } from '../helpers/supabase-mock.js';
+
+const supabaseMock = createSupabaseMock();
+const anthropicMock = { messages: { create: vi.fn() } };
+const slackMock = vi.fn(async () => ({ posted: true }));
+
+vi.mock('../../netlify/functions/_shared/supabase-admin.js', () => ({
+  getAdminClient: () => supabaseMock,
+  getAnonClient: () => supabaseMock,
+}));
+
+vi.mock('../../netlify/functions/_shared/anthropic.js', () => ({
+  getAnthropic: () => anthropicMock,
+  MODEL: 'claude-test-model',
+}));
+
+vi.mock('../../netlify/functions/_shared/slack.js', () => ({
+  slackAlert: slackMock,
+}));
+
+const FUTURE_ISO = new Date(Date.now() + 24 * 3600 * 1000).toISOString();
+
+function basePayload(overrides = {}) {
+  return {
+    platform: 'instagram',
+    channel_id: 'ch_pkfit_ig',
+    content_type: 'image',
+    media_urls: ['https://supabase.test/storage/v1/object/sign/img.jpg?token=abc'],
+    caption: 'Bar path drifts forward at lockout. Brace anterior to fix.',
+    schedule_mode: 'customScheduled',
+    schedule_at: FUTURE_ISO,
+    metadata: {
+      producer_task_id: '11111111-1111-1111-1111-111111111111',
+      source_asset_id: '22222222-2222-2222-2222-222222222222',
+      canon_version: 'canon-v3.2',
+      content_pillar: 'PKFIT-form-cues',
+      generation_model: 'claude-sonnet-4-5',
+      generation_prompt_hash: 'sha256:deadbeef',
+      distributor_agent_version: 'distributor-v0.4.1',
+    },
+    skip_canon_check: false,
+    ...overrides,
+  };
+}
+
+function makeEvent({ method = 'POST', headers = {}, body = basePayload() } = {}) {
+  return {
+    httpMethod: method,
+    headers: { authorization: 'Bearer tok', ...headers },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  };
+}
+
+async function loadHandler() {
+  const mod = await import('../../netlify/functions/distribute.js');
+  return mod.handler;
+}
+
+// Builds the supabase __setHandler that satisfies requireUser + checkRateLimit
+// + the distribute idempotency select + insert. Tests override individual table
+// branches by passing options.
+function setupSupabaseHandler({
+  user = { id: 'user-123', role: 'distributor' },
+  rateLimitRow = null,
+  existingDistribution = null,
+  insertResult = { data: { id: 'row-uuid-1' }, error: null },
+} = {}) {
+  supabaseMock.auth.getUser = vi.fn(async () => ({
+    data: { user: { id: user.id, email: 'distributor@axiom.test' } },
+    error: null,
+  }));
+  supabaseMock.__setHandler(({ table, op }) => {
+    if (table === 'profiles' && op === 'select') {
+      return { data: { id: user.id, role: user.role }, error: null };
+    }
+    if (table === 'rate_limits' && op === 'select') {
+      return { data: rateLimitRow, error: null };
+    }
+    if (table === 'rate_limits' && (op === 'upsert' || op === 'update')) {
+      return { data: null, error: null };
+    }
+    if (table === 'distributed_posts' && op === 'select') {
+      return { data: existingDistribution, error: null };
+    }
+    if (table === 'distributed_posts' && op === 'insert') {
+      return insertResult;
+    }
+    return { data: null, error: null };
+  });
+}
+
+function bufferSuccessJson() {
+  return {
+    data: {
+      createPost: {
+        post: {
+          id: 'buffer-post-abc',
+          text: 'irrelevant',
+          dueAt: FUTURE_ISO,
+          channelId: 'ch_pkfit_ig',
+          assets: [],
+        },
+      },
+    },
+  };
+}
+
+// fetch mock that:
+//   - HEAD requests to media URLs → 200
+//   - POST to api.buffer.com → configurable (default success)
+//   - anything else → 404
+function installFetchMock({ bufferImpl } = {}) {
+  const buffer = bufferImpl ?? (async () => ({
+    ok: true,
+    status: 200,
+    json: async () => bufferSuccessJson(),
+    text: async () => '',
+  }));
+  global.fetch = vi.fn(async (url, opts) => {
+    if (opts?.method === 'HEAD') {
+      return { ok: true, status: 200 };
+    }
+    if (typeof url === 'string' && url.startsWith('https://api.buffer.com')) {
+      return buffer(url, opts);
+    }
+    return { ok: false, status: 404, text: async () => '', json: async () => ({}) };
+  });
+  return global.fetch;
+}
+
+beforeEach(() => {
+  supabaseMock.__reset();
+  anthropicMock.messages.create.mockReset();
+  slackMock.mockClear();
+  process.env.BUFFER_ACCESS_TOKEN = 'buffer-test-token';
+  // Default canon score = 0.95 (publishes cleanly)
+  anthropicMock.messages.create.mockResolvedValue({
+    content: [{ text: '{"score": 0.95, "violations": [], "suggestions": []}' }],
+  });
+});
+
+describe('distribute — method gate', () => {
+  it('rejects non-POST with 405', async () => {
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({ method: 'GET' }));
+    expect(res.statusCode).toBe(405);
+  });
+});
+
+describe('distribute — auth gate', () => {
+  it('returns 401 when no Authorization header', async () => {
+    const handler = await loadHandler();
+    const res = await handler({ httpMethod: 'POST', headers: {}, body: JSON.stringify(basePayload()) });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 when Supabase rejects the token', async () => {
+    supabaseMock.auth.getUser = vi.fn(async () => ({ data: null, error: { message: 'invalid' } }));
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+describe('distribute — rate limit', () => {
+  it('returns 429 when the per-minute bucket is exhausted', async () => {
+    setupSupabaseHandler({
+      // Existing rate-limit row at the cap, within the current 60s window.
+      rateLimitRow: { window_start: new Date().toISOString(), count: 30 },
+    });
+    installFetchMock();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(429);
+    expect(res.headers['Retry-After']).toBeDefined();
+    const body = JSON.parse(res.body);
+    expect(body.error_code).toBe('RATE_LIMITED');
+    expect(body.retry_safe).toBe(true);
+  });
+});
+
+describe('distribute — payload validation', () => {
+  it('returns 400 when schedule_at is in the past', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    const past = new Date(Date.now() - 60_000).toISOString();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({ body: basePayload({ schedule_at: past }) }));
+    expect(res.statusCode).toBe(400);
+    const body = JSON.parse(res.body);
+    expect(body.error_code).toBe('INVALID_PAYLOAD');
+    expect(body.error_message).toMatch(/future/i);
+  });
+
+  it('returns 400 when schedule_at is not a valid ISO datetime', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({ body: basePayload({ schedule_at: 'not-a-date' }) }));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_message).toMatch(/ISO 8601/);
+  });
+
+  it('returns 400 when schedule_mode is customScheduled but schedule_at is missing', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    const handler = await loadHandler();
+    const body = basePayload();
+    delete body.schedule_at;
+    const res = await handler(makeEvent({ body }));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_message).toMatch(/schedule_at required/);
+  });
+
+  it('rejects unknown platform', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({ body: basePayload({ platform: 'snapchat' }) }));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_code).toBe('PLATFORM_NOT_SUPPORTED');
+  });
+
+  it('rejects caption that exceeds platform caption_max', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    const handler = await loadHandler();
+    // Threads cap = 500
+    const longCaption = 'x'.repeat(501);
+    const res = await handler(makeEvent({
+      body: basePayload({ platform: 'threads', caption: longCaption }),
+    }));
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_message).toMatch(/threads limit/);
+  });
+});
+
+describe('distribute — canon check', () => {
+  it('rejects with 422 when canon score is below the hard threshold (0.70)', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    anthropicMock.messages.create.mockResolvedValueOnce({
+      content: [{
+        text: '{"score": 0.55, "violations": ["uses exclamation point", "hype adjective: incredible"], "suggestions": ["drop the !", "swap incredible for specific mechanism"]}',
+      }],
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({ body: basePayload({ caption: 'This deadlift cue is incredible!' }) }));
+    expect(res.statusCode).toBe(422);
+    const body = JSON.parse(res.body);
+    expect(body.error_code).toBe('CANON_CHECK_FAILED');
+    expect(body.canon_score).toBeCloseTo(0.55, 2);
+    expect(body.violations).toHaveLength(2);
+    // Buffer must NOT have been called when canon fails closed.
+    const bufferCalls = global.fetch.mock.calls.filter(
+      ([url, opts]) => typeof url === 'string' && url.startsWith('https://api.buffer.com') && opts?.method === 'POST',
+    );
+    expect(bufferCalls).toHaveLength(0);
+  });
+
+  it('publishes but flags when canon score is between 0.70 and 0.90', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    anthropicMock.messages.create.mockResolvedValueOnce({
+      content: [{
+        text: '{"score": 0.82, "violations": ["soft cliche"], "suggestions": []}',
+      }],
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.ok).toBe(true);
+    expect(body.canon_flagged).toBe(true);
+    expect(body.canon_violations).toEqual(['soft cliche']);
+  });
+
+  it('skips the canon call when skip_canon_check is true', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({ body: basePayload({ skip_canon_check: true }) }));
+    expect(res.statusCode).toBe(200);
+    expect(anthropicMock.messages.create).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 INTERNAL_ERROR when canon check throws (Anthropic unavailable)', async () => {
+    setupSupabaseHandler();
+    installFetchMock();
+    anthropicMock.messages.create.mockRejectedValueOnce(new Error('Anthropic timeout'));
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).error_code).toBe('INTERNAL_ERROR');
+  });
+});
+
+describe('distribute — Buffer error paths', () => {
+  it('on transport failure → 502 BUFFER_API_ERROR with retry_safe + Slack WARN', async () => {
+    setupSupabaseHandler();
+    installFetchMock({
+      bufferImpl: async () => { throw new Error('ECONNRESET'); },
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(502);
+    const body = JSON.parse(res.body);
+    expect(body.error_code).toBe('BUFFER_API_ERROR');
+    expect(body.retry_safe).toBe(true);
+    expect(slackMock).toHaveBeenCalledWith(
+      'WARN',
+      expect.stringMatching(/Buffer API call failed/),
+    );
+  });
+
+  it('on Buffer auth error → 401 BUFFER_AUTH_ERROR + Slack CRITICAL', async () => {
+    setupSupabaseHandler();
+    installFetchMock({
+      bufferImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({ errors: [{ message: 'Unauthorized: invalid bearer token' }] }),
+        text: async () => '',
+      }),
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(401);
+    expect(JSON.parse(res.body).error_code).toBe('BUFFER_AUTH_ERROR');
+    expect(slackMock).toHaveBeenCalledWith(
+      'CRITICAL',
+      expect.stringMatching(/Buffer API auth failed/),
+    );
+  });
+
+  it('on MutationError branch → 422 BUFFER_API_ERROR + Slack WARN', async () => {
+    setupSupabaseHandler();
+    installFetchMock({
+      bufferImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          data: { createPost: { message: 'Channel disconnected — please reconnect Instagram in Buffer.' } },
+        }),
+        text: async () => '',
+      }),
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(422);
+    expect(JSON.parse(res.body).error_message).toMatch(/Channel disconnected/);
+    expect(slackMock).toHaveBeenCalledWith('WARN', expect.any(String));
+  });
+
+  it('on Buffer rate limit error → 429 BUFFER_RATE_LIMITED', async () => {
+    setupSupabaseHandler();
+    installFetchMock({
+      bufferImpl: async () => ({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          errors: [{
+            message: 'Rate limit exceeded',
+            extensions: { code: 'RATE_LIMIT_EXCEEDED', retryAfter: 42 },
+          }],
+        }),
+        text: async () => '',
+      }),
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(429);
+    const body = JSON.parse(res.body);
+    expect(body.error_code).toBe('BUFFER_RATE_LIMITED');
+    expect(body.retryAfter).toBe(42);
+  });
+});
+
+describe('distribute — idempotency', () => {
+  it('returns 409 DUPLICATE_DISTRIBUTION when the same task already published to the channel', async () => {
+    setupSupabaseHandler({
+      existingDistribution: {
+        id: 'row-existing',
+        buffer_post_id: 'buffer-post-prior',
+        scheduled_at: FUTURE_ISO,
+        buffer_status: 'scheduled',
+      },
+    });
+    installFetchMock();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(409);
+    const body = JSON.parse(res.body);
+    expect(body.error_code).toBe('DUPLICATE_DISTRIBUTION');
+    expect(body.existing_post_id).toBe('buffer-post-prior');
+  });
+});
+
+describe('distribute — TikTok routing', () => {
+  it('forces draft mode for TikTok regardless of caller schedule_mode', async () => {
+    setupSupabaseHandler();
+    const fetchMock = installFetchMock();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({
+      body: basePayload({ platform: 'tiktok', schedule_mode: 'customScheduled' }),
+    }));
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body.status).toBe('draft');
+    expect(body.note).toMatch(/TikTok/);
+
+    // Inspect the payload sent to Buffer — mode should be 'draft', not customScheduled.
+    const bufferCall = fetchMock.mock.calls.find(
+      ([url]) => typeof url === 'string' && url.startsWith('https://api.buffer.com'),
+    );
+    const sentBody = JSON.parse(bufferCall[1].body);
+    expect(sentBody.variables.input.mode).toBe('draft');
+  });
+});
+
+describe('distribute — happy path', () => {
+  it('schedules a post and returns the canonical success shape', async () => {
+    setupSupabaseHandler();
+    const fetchMock = installFetchMock();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(200);
+    const body = JSON.parse(res.body);
+    expect(body).toMatchObject({
+      ok: true,
+      post_id: 'buffer-post-abc',
+      status: 'scheduled',
+      canon_flagged: false,
+      distributed_post_row_id: 'row-uuid-1',
+    });
+    expect(body.canon_score).toBeGreaterThanOrEqual(0.9);
+
+    // Buffer was called once with a Bearer token (redacted check: header present).
+    const bufferCall = fetchMock.mock.calls.find(
+      ([url]) => typeof url === 'string' && url.startsWith('https://api.buffer.com'),
+    );
+    expect(bufferCall[1].headers['Authorization']).toBe('Bearer buffer-test-token');
+    expect(slackMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 500 when BUFFER_ACCESS_TOKEN is missing', async () => {
+    delete process.env.BUFFER_ACCESS_TOKEN;
+    setupSupabaseHandler();
+    installFetchMock();
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(500);
+    expect(JSON.parse(res.body).error).toMatch(/BUFFER_ACCESS_TOKEN/);
+  });
+
+  it('returns 400 MEDIA_UNREACHABLE when a media URL HEAD fails', async () => {
+    setupSupabaseHandler();
+    global.fetch = vi.fn(async (_url, opts) => {
+      if (opts?.method === 'HEAD') return { ok: false, status: 404 };
+      return { ok: false, status: 404, text: async () => '', json: async () => ({}) };
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body).error_code).toBe('MEDIA_UNREACHABLE');
+  });
+});


### PR DESCRIPTION
## Summary

Implements the AXIOM Distributor's posting endpoint (`POST /api/distribute`) per the integration spec. Schedules content to Buffer's GraphQL API on Percy's single-tenant Bearer token, with pre-publish brand-canon validation and an external join table for Observer-side correlation.

**Spec doc (local-only — not in repo):**
`/Users/percystewart/Library/Application Support/Claude/local-agent-mode-sessions/052c8876-0fa1-49e4-a016-7ce6bd524df8/c4ae7bce-e25a-4eac-835f-6f80bd5c9aeb/local_ad42b12f-b759-48d0-90fd-f6b3d00cf189/outputs/buffer-distributor-integration-spec.md`

## What lands

- **`netlify/functions/distribute.js`** — auth-gated, rate-limited, canon-checked Buffer GraphQL call. Mirrors `generate-image` / `generate-meal-plan` shape.
- **`netlify/functions/_shared/canon-check.js`** — wraps Anthropic to score captions against the PKFIT/AXIOM "Quiet Assassin" voice. Fail-closed at 0.70, soft-flag at 0.90.
- **`netlify/functions/_shared/slack.js`** — WARN / CRITICAL alerts to `#axiom-distributor-alerts`. No-op + console log when webhook is unset (alerts must never fail the caller).
- **`supabase/migrations/0025_distributed_posts.sql`** — external join table for Observer correlation. Buffer's `Post` type has no `customFields` surface, so we keep our own row keyed on `buffer_post_id`. Forward-references to `producer_tasks` / `assets` are typed `uuid` without FK so this migration ships before those tables exist. Unique constraint on `(producer_task_id, buffer_channel_id)` enforces idempotency.
- **22 Vitest tests** covering: auth gate, rate limit, schedule_at validation (past/non-ISO/missing), platform validation, caption-length validation, canon fail-closed, canon soft-flag, canon skip, canon Anthropic-failure, Buffer transport failure (retry-safe + Slack WARN), Buffer auth error (Slack CRITICAL), Buffer MutationError, Buffer rate limit, idempotency 409, TikTok forced-draft routing, happy path, missing-token 500, media-unreachable 400.
- **`README.md`** — adds `BUFFER_ACCESS_TOKEN` and `SLACK_WEBHOOK_URL_AXIOM_DISTRIBUTOR` to the server-only env table.

## Migration

`supabase/migrations/0025_distributed_posts.sql`:

- Table `public.distributed_posts` — Buffer-side identifiers + Observer correlation columns (canon_version, content_pillar, generation_model/prompt_hash, caption_canon_score, distributor_agent_version) + a `metadata_json` jsonb escape hatch.
- Indexes on `producer_task_id`, `content_pillar`, `canon_version`, and `(buffer_status, scheduled_at)` for the future status poller.
- Unique constraint `distributed_posts_task_channel_unique` on `(producer_task_id, buffer_channel_id)`.
- RLS enabled, no policies — server-only via service role (same pattern as `fal_usage`).

Apply with: `psql \"$SUPABASE_DB_URL\" < supabase/migrations/0025_distributed_posts.sql`

## Required env vars

Set in Netlify dashboard, never committed:

| Name | Context | Purpose |
|------|---------|---------|
| `BUFFER_ACCESS_TOKEN` | production | Personal Bearer key from `https://publish.buffer.com/settings/api` |
| `BUFFER_ACCESS_TOKEN` | deploy-preview | A separate dev key so prod and preview traffic are separable in Buffer's rate-limit accounting |
| `SLACK_WEBHOOK_URL_AXIOM_DISTRIBUTOR` | all | Optional. Incoming webhook for `#axiom-distributor-alerts`. Alerts log to console when unset. |

## Manual ops Percy walks post-merge

1. **Create a Buffer account** (or use the existing one) and pick a plan. Spec recommends Free tier for the smoke (3 channels, 10 posts/channel/month) → upgrade to Essentials annual (~$25/mo for 5 channels, $300/yr) once the integration proves out.
2. **Connect each social channel inside Buffer.** Channels → Connect a channel → OAuth into PKFIT IG, AXIOM LinkedIn (personal + company page), PKFIT YouTube, PKFIT TikTok (Buffer app handles TikTok; our API path uses drafts), optional Threads/FB. Buffer holds the per-platform tokens — pkfit-app never sees them.
3. **Generate the personal API key.** Buffer settings → API → "Create API key" → name it `pkfit-app-distributor-prod`. Generate a separate `pkfit-app-distributor-dev` for deploy previews.
4. **Drop tokens into Netlify env vars** per the table above (production context for prod key, deploy-preview context for dev key).
5. **Look up channel IDs.** From the `account.organizations` query and `channels` query in Buffer's GraphQL playground (or via a one-off curl). These are what the Producer/Distributor agents pass as `channel_id` in the `/api/distribute` payload. Recommend caching these in a future `channels_config` table.
6. **(Optional)** Wire `SLACK_WEBHOOK_URL_AXIOM_DISTRIBUTOR` to a dedicated `#axiom-distributor-alerts` channel, separate from the existing `#axiom-build-ops` webhook used by `axiom-overseer`.
7. **Deploy preview walk:** before merging, hit the preview's `/api/distribute` with a benign payload (Free tier, IG draft) and confirm a row lands in Buffer's UI.
8. **Apply migration `0025_distributed_posts.sql`** against prod Supabase.

## Out of scope for this PR (spec §5, §10 — separate follow-ups)

- Status poller (`netlify.toml` `[[scheduled-functions]]`, every 10 min) to backfill `published_url` and detect Bucket-D failures.
- Dead-letter retry job (every 30 min, 24h max) for transient Buffer 5xx.
- The Distributor agent process itself (system prompt is in the spec §9; lives in the AXIOM bench repo, not pkfit-app).
- TikTok Content Posting API direct integration (v2; v1 uses Buffer drafts).

## Test plan

- [x] `npm run test:coverage` — 80/80 pass, existing critical-path coverage gates intact.
- [x] `npm run build` — clean.
- [x] `npm run lint` — 0 errors (pre-existing warnings unchanged).
- [ ] Deploy preview: smoke `/api/distribute` against a Free-tier Buffer account, confirm a draft lands in Buffer UI.
- [ ] Apply migration to staging Supabase, confirm RLS denies anon-key reads, service role inserts succeed.
- [ ] Verify Slack webhook fires WARN on a synthetic Buffer 502 and CRITICAL on a synthetic 401.

🤖 Generated with [Claude Code](https://claude.com/claude-code)