### PR TITLE
fix(checkout): enable allow_promotion_codes

### DIFF
--- a/netlify/functions/create-checkout-session.js
+++ b/netlify/functions/create-checkout-session.js
@@ -34,6 +34,7 @@ export const handler = async (event) => {
       mode: 'subscription',
       payment_method_types: ['card'],
       line_items: [{ price: priceIdFor(tier, interval), quantity: 1 }],
+      allow_promotion_codes: true,
       client_reference_id: user.id,
       ...(existingPayment?.stripe_customer_id
         ? { customer: existingPayment.stripe_customer_id }


### PR DESCRIPTION
## Summary
- Adds `allow_promotion_codes: true` to the Stripe Checkout session created in `netlify/functions/create-checkout-session.js`.
- Without this flag, Stripe's hosted Checkout does not display the "Add promotion code" field, so coupons (including the 100% off testing coupon) cannot be applied.

## Test plan
- [ ] Deploy preview comes up green on Netlify
- [ ] Manual: hit `/billing` → Subscribe → confirm the "Add promotion code" link is now visible on Stripe Checkout
- [ ] Manual (post-merge): apply 100% off coupon end-to-end on live to validate the full flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)