### PR TITLE
feat: PKFIT iPhone-native coaching app — A-F + Owner Mode

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -18,6 +18,16 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 GEMINI_API_KEY=AIza...
 # fal.ai: image generation + the cinematic trailer one-shot generator.
 FAL_KEY=fal_xxx
+# AES-256-GCM secret for the profiles.medical_encrypted column. Generate
+# fresh — losing this means losing access to existing medical data.
+# openssl rand -base64 48
+MEDICAL_ENC_SECRET=replace-with-32-plus-char-random-string
+
+# ─── APIFY (Trainerize import) ────────────────────────────────────────────
+# Apify API token + the ID of the Trainerize-program-scraper actor (varies
+# per actor publisher; e.g. "username~trainerize-program-scraper").
+APIFY_API_TOKEN=apify_api_xxx
+APIFY_TRAINERIZE_ACTOR_ID=username~trainerize-program-scraper
 
 # Web Push — keep these in Netlify env, never commit real values.
 VAPID_PUBLIC_KEY=BDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,7 @@ SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 # gemini-2.5-pro by default; tiered users get gemini-2.5-flash.
 GEMINI_API_KEY=AIza...
 # fal.ai: image generation + the cinematic trailer one-shot generator.
-FAL_KEY=fal_xxx
+FAL_API_KEY=fal_xxx
 # AES-256-GCM secret for the profiles.medical_encrypted column. Generate
 # fresh — losing this means losing access to existing medical data.
 # openssl rand -base64 48

--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,12 @@ ANTHROPIC_API_KEY=sk-ant-xxx
 STRIPE_SECRET_KEY=sk_live_xxx
 STRIPE_WEBHOOK_SECRET=whsec_xxx
 SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
+# Gemini multimodal: powers /gemini-meal-photo (vision), /gemini-voice-turn
+# (audio transcription), /gemini-form-check (lift video review). Owner gets
+# gemini-2.5-pro by default; tiered users get gemini-2.5-flash.
+GEMINI_API_KEY=AIza...
+# fal.ai: image generation + the cinematic trailer one-shot generator.
+FAL_KEY=fal_xxx
 
 # Web Push — keep these in Netlify env, never commit real values.
 VAPID_PUBLIC_KEY=BDxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx

--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,17 @@ STRIPE_PRICE_PREMIUM_ANNUAL=price_xxx
 # pasted Anthropic API keys at rest. Generate with: openssl rand -base64 48
 BYO_KEY_SECRET=replace-with-32-plus-char-random-string
 
+# ─── OWNER MODE ───────────────────────────────────────────────────────────
+# Comma-separated list of email addresses that get unrestricted access:
+# Opus 4.7 by default, no tier gates, no rate limits, no subscription
+# requirement, separate owner-assistant system prompt (general-purpose
+# Quiet Assassin, no coaching-scope refusals). Server-side enforcement.
+OWNER_EMAILS=you@example.com
+# Same list, exposed to the browser bundle. Used only to render the /owner
+# tile + skip subscription redirects for the owner. Server still enforces
+# all privileged actions via OWNER_EMAILS.
+VITE_OWNER_EMAILS=you@example.com
+
 # ─── AXIOM OVERSEER (scheduled function — daily build brief) ──────────────
 # Personal access token (or fine-grained) with read access to issues + PRs.
 GITHUB_TOKEN=ghp_xxx

--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,15 @@ VAPID_PRIVATE_KEY=xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
 VAPID_SUBJECT=mailto:coach@pkfit.app
 
 # ─── STRIPE PRICE IDS (set real values in Netlify dashboard) ──────────────
+# Active 3-tier structure. tier1=$250 Haiku, tier2=$475 Sonnet, tier3=$750 Opus.
+STRIPE_PRICE_TIER1_MONTHLY=price_xxx
+STRIPE_PRICE_TIER1_ANNUAL=price_xxx
+STRIPE_PRICE_TIER2_MONTHLY=price_xxx
+STRIPE_PRICE_TIER2_ANNUAL=price_xxx
+STRIPE_PRICE_TIER3_MONTHLY=price_xxx
+STRIPE_PRICE_TIER3_ANNUAL=price_xxx
+# Legacy 4-tier price IDs. Retained so existing subscriptions keep resolving;
+# the webhook rolls them up to tier1/tier2/tier3 (see stripe-webhook.js).
 STRIPE_PRICE_PERFORMANCE_MONTHLY=price_xxx
 STRIPE_PRICE_PERFORMANCE_ANNUAL=price_xxx
 STRIPE_PRICE_IDENTITY_MONTHLY=price_xxx
@@ -27,6 +36,11 @@ STRIPE_PRICE_FULL_MONTHLY=price_xxx
 STRIPE_PRICE_FULL_ANNUAL=price_xxx
 STRIPE_PRICE_PREMIUM_MONTHLY=price_xxx
 STRIPE_PRICE_PREMIUM_ANNUAL=price_xxx
+
+# ─── BYO ANTHROPIC KEY (tier3 subscribers) ────────────────────────────────
+# 32+ char random secret used to AES-256-GCM encrypt tier3 subscribers'
+# pasted Anthropic API keys at rest. Generate with: openssl rand -base64 48
+BYO_KEY_SECRET=replace-with-32-plus-char-random-string
 
 # ─── AXIOM OVERSEER (scheduled function — daily build brief) ──────────────
 # Personal access token (or fine-grained) with read access to issues + PRs.

--- a/netlify/functions/_prompts/owner-assistant.md
+++ b/netlify/functions/_prompts/owner-assistant.md
@@ -1,0 +1,25 @@
+# Owner Assistant — Unrestricted
+
+You are speaking with the owner of PKFIT — Percy. Voice and posture stay
+locked to the Quiet Assassin: surgical, calm, mechanism-first, no hype, no
+emoji, no exclamation points, no rhetorical sleight of hand.
+
+Scope is **not** restricted. Unlike the client assistant, you are not bound to
+training, nutrition, habits, recovery, or coaching topics. Percy may ask
+about anything — code, strategy, business, writing, research, personal life,
+edge cases, philosophy, debugging, vendor evaluation, system design,
+medical/legal/financial questions, anything. Engage directly.
+
+If a question is genuinely ambiguous, ask one clarifying question and stop.
+Do not pre-explain, do not enumerate options when the right answer is
+specific, do not append summaries to short answers.
+
+When tooling, code, or third-party APIs are involved, prefer concrete:
+filenames, line numbers, exact commands, exact env vars, exact SQL.
+
+Refusals are reserved for content that is illegal to produce regardless of
+who asks (CSAM, weapons-of-mass-destruction synthesis, etc.). Everything
+else is in scope.
+
+Length: match the question. A one-line answer for a one-line question. Long
+form only when the work warrants it.

--- a/netlify/functions/_prompts/workout-generator.md
+++ b/netlify/functions/_prompts/workout-generator.md
@@ -30,4 +30,14 @@ Rules:
 - Prioritize compound lifts. Volume where it moves the outcome. No filler.
 - If constraint mentions an injury, substitute or regress. State the substitution in the notes.
 - No more than 6 working sets per major muscle group per day.
-- Keep exercise names canonical (back squat, conventional deadlift, bench press, row, press).
+- Keep exercise names canonical so the client app can match a curated demo
+  video. Use the exact title-cased names from this set when applicable:
+    Back Squat, Front Squat, Conventional Deadlift, Romanian Deadlift,
+    Bench Press, Overhead Press, Barbell Row, Pull-Up, Chin-Up, Dip,
+    Lat Pulldown, Seated Cable Row, Incline DB Press, DB Bench Press,
+    Lateral Raise, Rear Delt Fly, Face Pull, Barbell Curl, Hammer Curl,
+    Triceps Pushdown, Skullcrusher, Walking Lunge, Bulgarian Split Squat,
+    Hip Thrust, Leg Press, Leg Curl, Leg Extension, Calf Raise, Plank,
+    Hanging Leg Raise, Ab Wheel Rollout.
+  When you must use a movement outside this list, still use a precise,
+  conventional name (e.g. "Cable Crossover", not "Chest Cable Thing").

--- a/netlify/functions/_shared/anthropic.js
+++ b/netlify/functions/_shared/anthropic.js
@@ -19,13 +19,14 @@ function computeHere() {
 }
 const here = computeHere();
 
-let client = null;
-export function getAnthropic() {
-  if (client) return client;
+let defaultClient = null;
+export function getAnthropic(apiKeyOverride) {
+  if (apiKeyOverride) return new Anthropic({ apiKey: apiKeyOverride });
+  if (defaultClient) return defaultClient;
   const apiKey = process.env.ANTHROPIC_API_KEY;
   if (!apiKey) throw new Error('ANTHROPIC_API_KEY missing');
-  client = new Anthropic({ apiKey });
-  return client;
+  defaultClient = new Anthropic({ apiKey });
+  return defaultClient;
 }
 
 // Resolve the prompt file across dev and the Netlify Lambda bundle. Two
@@ -70,9 +71,22 @@ export function loadPrompt(name) {
   );
 }
 
-// Latest Claude Sonnet 4 model. "claude-sonnet-4" in the brief maps to this
-// dated ID so a dated model is pinned in production.
-export const MODEL = 'claude-sonnet-4-5-20250929';
+// Tier → model routing. Tier 1 ($250) gets Haiku 4.5, Tier 2 ($475) gets
+// Sonnet 4.6, Tier 3 ($750) gets Opus 4.7. Trial defaults to Haiku.
+export const MODEL_BY_TIER = {
+  trial: 'claude-haiku-4-5-20251001',
+  tier1: 'claude-haiku-4-5-20251001',
+  tier2: 'claude-sonnet-4-6',
+  tier3: 'claude-opus-4-7',
+};
+
+export function pickModel(tier) {
+  return MODEL_BY_TIER[tier] || MODEL_BY_TIER.trial;
+}
+
+// Back-compat shim: scheduled functions and tests that don't have a caller
+// tier (e.g. axiom-overseer cron) fall back to Sonnet.
+export const MODEL = MODEL_BY_TIER.tier2;
 
 // Strip characters that violate PKFIT voice (emoji, exclamation points).
 // Safe to run per-chunk: only character-level substitutions, no trim.

--- a/netlify/functions/_shared/auth.js
+++ b/netlify/functions/_shared/auth.js
@@ -1,4 +1,5 @@
 import { getAnonClient, getAdminClient } from './supabase-admin.js';
+import { isOwnerEmail } from './owner.js';
 
 export async function requireUser(event) {
   const header = event.headers?.authorization || event.headers?.Authorization;
@@ -18,7 +19,11 @@ export async function requireUser(event) {
 
   const admin = getAdminClient();
   const { data: profile } = await admin.from('profiles').select('*').eq('id', data.user.id).maybeSingle();
-  return { user: data.user, profile, role: profile?.role ?? 'client' };
+  // Owner identity is established by server env var, never DB state. The
+  // owner role overrides whatever role the profile row claims so a
+  // privileged action cannot be unlocked by tampering with profiles.role.
+  const role = isOwnerEmail(data.user.email) ? 'owner' : profile?.role ?? 'client';
+  return { user: data.user, profile, role };
 }
 
 export function jsonResponse(statusCode, body) {

--- a/netlify/functions/_shared/byo-crypto.js
+++ b/netlify/functions/_shared/byo-crypto.js
@@ -1,0 +1,29 @@
+import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'node:crypto';
+
+const ALGO = 'aes-256-gcm';
+const IV_LEN = 12;
+const TAG_LEN = 16;
+
+function getKey() {
+  const secret = process.env.BYO_KEY_SECRET;
+  if (!secret) throw new Error('BYO_KEY_SECRET missing');
+  return createHash('sha256').update(secret).digest();
+}
+
+export function encryptByoKey(plaintext) {
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, getKey(), iv);
+  const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ct]);
+}
+
+export function decryptByoKey(stored) {
+  const buf = Buffer.isBuffer(stored) ? stored : Buffer.from(stored, 'base64');
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+  const ct = buf.subarray(IV_LEN + TAG_LEN);
+  const decipher = createDecipheriv(ALGO, getKey(), iv);
+  decipher.setAuthTag(tag);
+  return Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8');
+}

--- a/netlify/functions/_shared/gemini.js
+++ b/netlify/functions/_shared/gemini.js
@@ -1,0 +1,65 @@
+import { GoogleGenerativeAI } from '@google/generative-ai';
+
+// Tier → Gemini model. Owner gets the highest-reasoning model with the
+// largest context. Everyone else gets the fast/cheap variant since tier is
+// only meant to gate Anthropic spend, not Gemini multimodal access. If you
+// want to reverse this, override per call site by passing `model` explicitly.
+export const GEMINI_MODEL_BY_ROLE = {
+  owner: 'gemini-2.5-pro',
+  coach: 'gemini-2.5-flash',
+  client: 'gemini-2.5-flash',
+};
+
+export function pickGeminiModel(role) {
+  return GEMINI_MODEL_BY_ROLE[role] || GEMINI_MODEL_BY_ROLE.client;
+}
+
+let defaultClient = null;
+export function getGemini(apiKeyOverride) {
+  if (apiKeyOverride) return new GoogleGenerativeAI(apiKeyOverride);
+  if (defaultClient) return defaultClient;
+  const apiKey = process.env.GEMINI_API_KEY;
+  if (!apiKey) throw new Error('GEMINI_API_KEY missing');
+  defaultClient = new GoogleGenerativeAI(apiKey);
+  return defaultClient;
+}
+
+// Run a prompt with one inline file (image/audio/video) and return the
+// concatenated text from the first candidate. `data` is base64 (no data:
+// prefix). `mimeType` examples: image/jpeg, image/png, audio/webm, audio/mp4,
+// video/mp4. Errors propagate to the caller.
+export async function generateWithMedia({ role, model, prompt, data, mimeType, generationConfig }) {
+  const client = getGemini();
+  const modelName = model || pickGeminiModel(role);
+  const generative = client.getGenerativeModel({
+    model: modelName,
+    generationConfig: generationConfig ?? { temperature: 0.2 },
+  });
+  const result = await generative.generateContent([
+    { inlineData: { data, mimeType } },
+    { text: prompt },
+  ]);
+  return result.response.text();
+}
+
+// Best-effort JSON parser for Gemini responses. Strips markdown fences and
+// finds the largest balanced { ... } block if the model wraps prose around
+// the JSON. Returns null if nothing parses.
+export function parseJsonLoose(text) {
+  if (!text) return null;
+  const stripped = String(text)
+    .replace(/^```(?:json)?\s*/i, '')
+    .replace(/```\s*$/, '')
+    .trim();
+  try {
+    return JSON.parse(stripped);
+  } catch {
+    const match = stripped.match(/\{[\s\S]*\}/);
+    if (!match) return null;
+    try {
+      return JSON.parse(match[0]);
+    } catch {
+      return null;
+    }
+  }
+}

--- a/netlify/functions/_shared/medical-crypto.js
+++ b/netlify/functions/_shared/medical-crypto.js
@@ -1,0 +1,45 @@
+import { createCipheriv, createDecipheriv, randomBytes, createHash } from 'node:crypto';
+
+// AES-256-GCM at-rest encryption for the profiles.medical_encrypted column.
+// Keyed by MEDICAL_ENC_SECRET (server env, never in the bundle). Layout:
+//   IV (12 bytes) || authTag (16 bytes) || ciphertext
+//
+// Threat model: Supabase data leak / accidental dump must not expose
+// medical PII. The secret lives in Netlify env, which is a separate trust
+// boundary. Decryption happens only inside Netlify Functions and only for
+// the authenticated owner of the row.
+
+const ALGO = 'aes-256-gcm';
+const IV_LEN = 12;
+const TAG_LEN = 16;
+
+function getKey() {
+  const secret = process.env.MEDICAL_ENC_SECRET;
+  if (!secret) throw new Error('MEDICAL_ENC_SECRET missing');
+  return createHash('sha256').update(secret).digest();
+}
+
+export function encryptMedical(plaintextJson) {
+  const data = JSON.stringify(plaintextJson ?? {});
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGO, getKey(), iv);
+  const ct = Buffer.concat([cipher.update(data, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  return Buffer.concat([iv, tag, ct]);
+}
+
+export function decryptMedical(stored) {
+  if (!stored) return null;
+  const buf = Buffer.isBuffer(stored) ? stored : Buffer.from(stored, 'base64');
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+  const ct = buf.subarray(IV_LEN + TAG_LEN);
+  const decipher = createDecipheriv(ALGO, getKey(), iv);
+  decipher.setAuthTag(tag);
+  const plaintext = Buffer.concat([decipher.update(ct), decipher.final()]).toString('utf8');
+  try {
+    return JSON.parse(plaintext);
+  } catch {
+    return null;
+  }
+}

--- a/netlify/functions/_shared/owner.js
+++ b/netlify/functions/_shared/owner.js
@@ -1,0 +1,18 @@
+// Owner identity check. Server-only — the OWNER_EMAILS env var is the source
+// of truth and must NEVER be inferred from client state. Client-side hints
+// (VITE_OWNER_EMAILS) only control UI visibility; every privileged action
+// is gated server-side via this helper.
+
+function parseList(raw) {
+  if (!raw) return [];
+  return raw
+    .split(',')
+    .map((s) => s.trim().toLowerCase())
+    .filter(Boolean);
+}
+
+export function isOwnerEmail(email) {
+  if (!email) return false;
+  const list = parseList(process.env.OWNER_EMAILS);
+  return list.includes(String(email).trim().toLowerCase());
+}

--- a/netlify/functions/_shared/stripe.js
+++ b/netlify/functions/_shared/stripe.js
@@ -32,6 +32,11 @@ export function __resetStripeClients() {
 }
 
 export const PLAN_AMOUNTS = {
+  // Active tiers (tier-aware Claude routing): Haiku / Sonnet / Opus.
+  tier1: { monthly: 250, annual: 2490 },
+  tier2: { monthly: 475, annual: 4731 },
+  tier3: { monthly: 750, annual: 7470 },
+  // Legacy plan names retained so historical payments rows still resolve.
   performance: { monthly: 250, annual: 2490 },
   identity: { monthly: 350, annual: 3486 },
   full: { monthly: 450, annual: 4482 },

--- a/netlify/functions/_shared/tier.js
+++ b/netlify/functions/_shared/tier.js
@@ -1,4 +1,4 @@
-import { pickModel } from './anthropic.js';
+import { pickModel, MODEL_BY_TIER } from './anthropic.js';
 import { decryptByoKey } from './byo-crypto.js';
 
 const LEGACY_PLAN_TO_TIER = {
@@ -15,7 +15,21 @@ export function tierFromProfile(profile) {
   return LEGACY_PLAN_TO_TIER[raw] ?? 'trial';
 }
 
-export function resolveModelAndKey(profile) {
+// `role` is the effective role from requireUser — 'owner' bypasses tier and
+// always gets Opus, with BYO key support so the owner can route their own
+// usage through their own Anthropic billing if they choose.
+export function resolveModelAndKey(profile, role) {
+  if (role === 'owner') {
+    let apiKeyOverride;
+    if (profile?.byo_anthropic_key_encrypted) {
+      try {
+        apiKeyOverride = decryptByoKey(profile.byo_anthropic_key_encrypted);
+      } catch {
+        apiKeyOverride = undefined;
+      }
+    }
+    return { tier: 'owner', model: MODEL_BY_TIER.tier3, apiKeyOverride };
+  }
   const tier = tierFromProfile(profile);
   const model = pickModel(tier);
   let apiKeyOverride;

--- a/netlify/functions/_shared/tier.js
+++ b/netlify/functions/_shared/tier.js
@@ -1,0 +1,32 @@
+import { pickModel } from './anthropic.js';
+import { decryptByoKey } from './byo-crypto.js';
+
+const LEGACY_PLAN_TO_TIER = {
+  performance: 'tier1',
+  identity: 'tier1',
+  full: 'tier2',
+  premium: 'tier3',
+};
+
+export function tierFromProfile(profile) {
+  if (!profile) return 'trial';
+  const raw = profile.plan ?? profile.tier ?? 'trial';
+  if (raw === 'tier1' || raw === 'tier2' || raw === 'tier3' || raw === 'trial') return raw;
+  return LEGACY_PLAN_TO_TIER[raw] ?? 'trial';
+}
+
+export function resolveModelAndKey(profile) {
+  const tier = tierFromProfile(profile);
+  const model = pickModel(tier);
+  let apiKeyOverride;
+  if (tier === 'tier3' && profile?.byo_anthropic_key_encrypted) {
+    try {
+      apiKeyOverride = decryptByoKey(profile.byo_anthropic_key_encrypted);
+    } catch {
+      // Fall back to platform key if decryption fails. Do not throw — the
+      // user still gets service, just on the platform's billing.
+      apiKeyOverride = undefined;
+    }
+  }
+  return { tier, model, apiKeyOverride };
+}

--- a/netlify/functions/apify-import.js
+++ b/netlify/functions/apify-import.js
@@ -1,0 +1,105 @@
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { getAdminClient } from './_shared/supabase-admin.js';
+import { checkRateLimit } from './_shared/rate-limit.js';
+
+// Apify-driven Trainerize import. Body: { sourceUrl }.
+//
+// Triggers the configured Trainerize Apify actor with the user's source URL,
+// polls until the run completes, fetches the dataset items, normalizes into
+// a `programs` row, and inserts. Trainerize is the only supported source in
+// v1 — generalize the dispatcher when other actors land.
+//
+// Env:
+//   APIFY_API_TOKEN              required
+//   APIFY_TRAINERIZE_ACTOR_ID    e.g. "username~trainerize-program-scraper"
+//
+// Polling is bounded to ~110s (Netlify Function timeout is ~10s by default
+// for sync handlers; this function runs as a Netlify Background Function or
+// the call returns 202 with the runId for the client to poll). For v1 we do
+// the simplest thing — short poll with hard cap, return 202 if still running.
+
+const POLL_INTERVAL_MS = 5_000;
+const MAX_POLLS = 18; // ~90s total
+
+async function gh(url, opts = {}) {
+  const res = await fetch(url, opts);
+  if (!res.ok) {
+    const text = await res.text().catch(() => '');
+    throw new Error(`Apify ${res.status}: ${text.slice(0, 200)}`);
+  }
+  return res.json();
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' });
+  try {
+    const { user, role } = await requireUser(event);
+    const body = JSON.parse(event.body || '{}');
+    const sourceUrl = typeof body.sourceUrl === 'string' ? body.sourceUrl.trim() : '';
+    if (!/^https?:\/\//i.test(sourceUrl)) {
+      return jsonResponse(400, { error: 'sourceUrl (https) required' });
+    }
+
+    const token = process.env.APIFY_API_TOKEN;
+    const actorId = process.env.APIFY_TRAINERIZE_ACTOR_ID;
+    if (!token || !actorId) {
+      return jsonResponse(500, { error: 'Apify is not configured server-side' });
+    }
+
+    const limit = role === 'owner' ? { allowed: true } : await checkRateLimit({
+      userId: user.id,
+      bucket: 'apify-import',
+      max: 5,
+      windowSec: 3600,
+    });
+    if (!limit.allowed) {
+      return jsonResponse(429, { error: `Rate limit. Wait ${limit.retryAfterSec ?? 60}s.` });
+    }
+
+    // Kick off the actor synchronously up to 60s, then poll if needed.
+    const startUrl = `https://api.apify.com/v2/acts/${encodeURIComponent(actorId)}/runs?token=${token}&waitForFinish=60`;
+    const startRes = await gh(startUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ startUrls: [{ url: sourceUrl }] }),
+    });
+    const runId = startRes?.data?.id;
+    let status = startRes?.data?.status;
+    let datasetId = startRes?.data?.defaultDatasetId;
+
+    for (let i = 0; i < MAX_POLLS && status !== 'SUCCEEDED' && status !== 'FAILED' && status !== 'ABORTED'; i += 1) {
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+      const poll = await gh(`https://api.apify.com/v2/actor-runs/${runId}?token=${token}`);
+      status = poll?.data?.status;
+      datasetId = poll?.data?.defaultDatasetId;
+    }
+
+    if (status !== 'SUCCEEDED') {
+      return jsonResponse(202, { runId, status, message: 'Import is still running. Poll the runId to retrieve.' });
+    }
+
+    const items = await gh(`https://api.apify.com/v2/datasets/${datasetId}/items?token=${token}&format=json&clean=1`);
+    const first = Array.isArray(items) ? items[0] : null;
+    if (!first) {
+      return jsonResponse(502, { error: 'Apify run returned no items' });
+    }
+
+    const admin = getAdminClient();
+    const { data, error } = await admin
+      .from('programs')
+      .insert({
+        client_id: user.id,
+        week_number: Number(first.week_number ?? 1),
+        schedule: first.schedule ?? { title: first.title ?? 'Imported program', source: 'trainerize' },
+        exercises: Array.isArray(first.exercises) ? first.exercises : [],
+        status: 'draft',
+      })
+      .select()
+      .maybeSingle();
+    if (error) return jsonResponse(500, { error: error.message });
+
+    return jsonResponse(200, { program: data });
+  } catch (e) {
+    return errorResponse(e);
+  }
+};

--- a/netlify/functions/client-assistant.js
+++ b/netlify/functions/client-assistant.js
@@ -1,6 +1,7 @@
 import { getAdminClient, getAnonClient } from './_shared/supabase-admin.js';
 import { getAnthropic, loadPrompt, sanitizeVoice, bannedTokensCleanup } from './_shared/anthropic.js';
 import { resolveModelAndKey } from './_shared/tier.js';
+import { isOwnerEmail } from './_shared/owner.js';
 import { checkRateLimit } from './_shared/rate-limit.js';
 
 const MAX_CONTEXT_MESSAGES = 24;
@@ -95,7 +96,9 @@ export default async (req) => {
     });
   }
 
-  const limit = await checkRateLimit({
+  const isOwner = isOwnerEmail(user.email);
+
+  const limit = isOwner ? { allowed: true } : await checkRateLimit({
     userId: user.id,
     bucket: 'assistant',
     max: ASSISTANT_RPM,
@@ -115,7 +118,8 @@ export default async (req) => {
     .select('plan, byo_anthropic_key_encrypted')
     .eq('id', user.id)
     .maybeSingle();
-  const { model, apiKeyOverride } = resolveModelAndKey(profile);
+  const role = isOwner ? 'owner' : profile?.role ?? 'client';
+  const { model, apiKeyOverride } = resolveModelAndKey(profile, role);
 
   let conversationId = body.conversationId ?? null;
   let conversationContext = [];
@@ -165,10 +169,14 @@ export default async (req) => {
     .filter((m) => m.role === 'user' || m.role === 'assistant')
     .map((m) => ({ role: m.role, content: m.content.slice(0, 8000) }));
 
+  // Owner gets a separate, unrestricted Quiet Assassin system prompt — no
+  // client-coaching scope refusals (medical / legal / financial / off-topic).
+  // The pkfit-system.md voice rules still apply: no emoji, no exclamation
+  // points, mechanism-first.
   const system =
     loadPrompt('pkfit-system.md') +
     '\n\n' +
-    loadPrompt('client-assistant.md') +
+    loadPrompt(role === 'owner' ? 'owner-assistant.md' : 'client-assistant.md') +
     renderPinnedContext(conversationContext);
 
   const encoder = new TextEncoder();

--- a/netlify/functions/client-assistant.js
+++ b/netlify/functions/client-assistant.js
@@ -1,5 +1,6 @@
 import { getAdminClient, getAnonClient } from './_shared/supabase-admin.js';
-import { getAnthropic, loadPrompt, MODEL, sanitizeVoice, bannedTokensCleanup } from './_shared/anthropic.js';
+import { getAnthropic, loadPrompt, sanitizeVoice, bannedTokensCleanup } from './_shared/anthropic.js';
+import { resolveModelAndKey } from './_shared/tier.js';
 import { checkRateLimit } from './_shared/rate-limit.js';
 
 const MAX_CONTEXT_MESSAGES = 24;
@@ -109,6 +110,13 @@ export default async (req) => {
 
   const admin = getAdminClient();
 
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('plan, byo_anthropic_key_encrypted')
+    .eq('id', user.id)
+    .maybeSingle();
+  const { model, apiKeyOverride } = resolveModelAndKey(profile);
+
   let conversationId = body.conversationId ?? null;
   let conversationContext = [];
   if (conversationId) {
@@ -174,9 +182,9 @@ export default async (req) => {
 
       let fullText = '';
       try {
-        const anthropic = getAnthropic();
+        const anthropic = getAnthropic(apiKeyOverride);
         const anthStream = anthropic.messages.stream({
-          model: MODEL,
+          model,
           max_tokens: 1024,
           system,
           messages,

--- a/netlify/functions/create-checkout-session.js
+++ b/netlify/functions/create-checkout-session.js
@@ -2,7 +2,7 @@ import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
 import { getAdminClient } from './_shared/supabase-admin.js';
 import { getStripe, priceIdFor } from './_shared/stripe.js';
 
-const VALID_TIERS = new Set(['performance', 'identity', 'full', 'premium']);
+const VALID_TIERS = new Set(['tier1', 'tier2', 'tier3']);
 const VALID_INTERVALS = new Set(['monthly', 'annual']);
 
 export const handler = async (event) => {

--- a/netlify/functions/gemini-form-check.js
+++ b/netlify/functions/gemini-form-check.js
@@ -1,0 +1,78 @@
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { generateWithMedia, parseJsonLoose } from './_shared/gemini.js';
+import { checkRateLimit } from './_shared/rate-limit.js';
+
+// Form-check on a short lift video. Body: { video: <base64>, mimeType:
+// 'video/mp4', exercise: 'back squat' }. Returns:
+//   { cues: [{ tag, severity, note }], summary, fix_priority }.
+//
+// Voice constraint: the prompt enforces PKFIT's Quiet Assassin tone so the
+// output reads like the rest of the app. No emoji, no exclamation points.
+
+function buildPrompt(exercise) {
+  return [
+    `You are reviewing a lifting video clip of: ${exercise || 'an unknown lift'}.`,
+    '',
+    'Watch the clip and identify form deviations. Use mechanism-first language.',
+    'Voice rules: no emoji, no exclamation points, no hype, no rhetorical',
+    'questions. State what is happening and what to change.',
+    '',
+    'Return ONLY a JSON object (no prose, no markdown) with this shape:',
+    '{',
+    '  "cues": [{ "tag": string, "severity": "low"|"med"|"high", "note": string }],',
+    '  "summary": string,',
+    '  "fix_priority": string',
+    '}',
+    '',
+    '- cues: 1 to 5 entries; tag is short (e.g. "knee valgus", "bar path",',
+    '  "depth", "spinal flexion"); note is one specific sentence.',
+    '- summary: one sentence overview.',
+    '- fix_priority: the single highest-leverage cue to address first.',
+  ].join('\n');
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' });
+  try {
+    const { user, role } = await requireUser(event);
+    const body = JSON.parse(event.body || '{}');
+    const video = body.video;
+    const mimeType = body.mimeType || 'video/mp4';
+    const exercise = typeof body.exercise === 'string' ? body.exercise.slice(0, 80) : '';
+    if (!video || typeof video !== 'string') {
+      return jsonResponse(400, { error: 'video (base64) required' });
+    }
+    if (!/^video\/(mp4|quicktime|webm|mpeg)$/i.test(mimeType)) {
+      return jsonResponse(400, { error: 'Unsupported video type' });
+    }
+
+    const limit = role === 'owner' ? { allowed: true } : await checkRateLimit({
+      userId: user.id,
+      bucket: 'gemini-form-check',
+      max: 20,
+      windowSec: 3600,
+    });
+    if (!limit.allowed) {
+      return {
+        statusCode: 429,
+        headers: { 'Content-Type': 'application/json', 'Retry-After': String(limit.retryAfterSec ?? 60) },
+        body: JSON.stringify({ error: `Rate limit. Wait ${limit.retryAfterSec ?? 60}s.` }),
+      };
+    }
+
+    const text = await generateWithMedia({
+      role,
+      prompt: buildPrompt(exercise),
+      data: video,
+      mimeType,
+      generationConfig: { temperature: 0.2, responseMimeType: 'application/json' },
+    });
+    const parsed = parseJsonLoose(text);
+    if (!parsed?.cues) {
+      return jsonResponse(502, { error: 'Vision returned unparseable form check', raw: text?.slice(0, 200) });
+    }
+    return jsonResponse(200, parsed);
+  } catch (e) {
+    return errorResponse(e);
+  }
+};

--- a/netlify/functions/gemini-meal-photo.js
+++ b/netlify/functions/gemini-meal-photo.js
@@ -1,0 +1,77 @@
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { generateWithMedia, parseJsonLoose } from './_shared/gemini.js';
+import { checkRateLimit } from './_shared/rate-limit.js';
+
+// Snap-a-meal estimator. Body: { image: <base64>, mimeType: 'image/jpeg' }.
+// Returns: { items: [{name, grams, kcal, p, c, f}], total: {kcal,p,c,f},
+//           confidence: 0..1, notes }.
+//
+// The user confirms or edits the result before it's persisted; the client
+// app pre-fills the Meals form. We never write directly from this endpoint.
+
+const PROMPT = [
+  'You are a sports nutritionist. The image shows a meal.',
+  '',
+  'Identify each visible food item, estimate its weight in grams, and compute',
+  'kilocalories and macronutrients (protein, carbs, fat — grams) using',
+  'standard published values. Use US units. Be specific (e.g. "grilled',
+  'chicken breast" not "chicken").',
+  '',
+  'Return ONLY a JSON object with this exact shape (no prose, no markdown):',
+  '{',
+  '  "items": [{ "name": string, "grams": number, "kcal": number,',
+  '             "p": number, "c": number, "f": number }],',
+  '  "total": { "kcal": number, "p": number, "c": number, "f": number },',
+  '  "confidence": number,',
+  '  "notes": string',
+  '}',
+  '',
+  'confidence is 0-1 reflecting how clearly the food + portion are visible.',
+  'notes is short — at most one sentence — flag any guesses or ambiguity.',
+].join('\n');
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' });
+  try {
+    const { user, role } = await requireUser(event);
+    const body = JSON.parse(event.body || '{}');
+    const image = body.image;
+    const mimeType = body.mimeType || 'image/jpeg';
+    if (!image || typeof image !== 'string') {
+      return jsonResponse(400, { error: 'image (base64) required' });
+    }
+    if (!/^image\/(jpeg|png|webp|heic|heif)$/i.test(mimeType)) {
+      return jsonResponse(400, { error: 'Unsupported image type' });
+    }
+
+    const limit = role === 'owner' ? { allowed: true } : await checkRateLimit({
+      userId: user.id,
+      bucket: 'gemini-meal-photo',
+      max: 30,
+      windowSec: 3600,
+    });
+    if (!limit.allowed) {
+      return {
+        statusCode: 429,
+        headers: { 'Content-Type': 'application/json', 'Retry-After': String(limit.retryAfterSec ?? 60) },
+        body: JSON.stringify({ error: `Rate limit. Wait ${limit.retryAfterSec ?? 60}s.` }),
+      };
+    }
+
+    const text = await generateWithMedia({
+      role,
+      prompt: PROMPT,
+      data: image,
+      mimeType,
+      generationConfig: { temperature: 0.1, responseMimeType: 'application/json' },
+    });
+
+    const parsed = parseJsonLoose(text);
+    if (!parsed?.items) {
+      return jsonResponse(502, { error: 'Vision returned unparseable estimate', raw: text?.slice(0, 200) });
+    }
+    return jsonResponse(200, parsed);
+  } catch (e) {
+    return errorResponse(e);
+  }
+};

--- a/netlify/functions/gemini-voice-turn.js
+++ b/netlify/functions/gemini-voice-turn.js
@@ -1,0 +1,58 @@
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { generateWithMedia } from './_shared/gemini.js';
+import { checkRateLimit } from './_shared/rate-limit.js';
+
+// Voice → transcript. Body: { audio: <base64>, mimeType: 'audio/webm' }.
+// Returns: { transcript: string }.
+//
+// The client posts the recording, gets a transcript back, then sends the
+// transcript through the existing /client-assistant streaming endpoint.
+// Splitting transcribe + chat keeps the streaming path unchanged.
+
+const PROMPT = [
+  'Transcribe the spoken audio verbatim. Return only the transcript, no',
+  'speaker labels, no timestamps, no commentary. If the audio is silent or',
+  'unintelligible, return an empty string.',
+].join(' ');
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' });
+  try {
+    const { user, role } = await requireUser(event);
+    const body = JSON.parse(event.body || '{}');
+    const audio = body.audio;
+    const mimeType = body.mimeType || 'audio/webm';
+    if (!audio || typeof audio !== 'string') {
+      return jsonResponse(400, { error: 'audio (base64) required' });
+    }
+    if (!/^audio\/(webm|mp4|mpeg|wav|ogg|flac|m4a|aac)$/i.test(mimeType)) {
+      return jsonResponse(400, { error: 'Unsupported audio type' });
+    }
+
+    const limit = role === 'owner' ? { allowed: true } : await checkRateLimit({
+      userId: user.id,
+      bucket: 'gemini-voice-turn',
+      max: 60,
+      windowSec: 3600,
+    });
+    if (!limit.allowed) {
+      return {
+        statusCode: 429,
+        headers: { 'Content-Type': 'application/json', 'Retry-After': String(limit.retryAfterSec ?? 60) },
+        body: JSON.stringify({ error: `Rate limit. Wait ${limit.retryAfterSec ?? 60}s.` }),
+      };
+    }
+
+    const transcript = (await generateWithMedia({
+      role,
+      prompt: PROMPT,
+      data: audio,
+      mimeType,
+      generationConfig: { temperature: 0.0 },
+    }))?.trim() ?? '';
+
+    return jsonResponse(200, { transcript });
+  } catch (e) {
+    return errorResponse(e);
+  }
+};

--- a/netlify/functions/generate-meal-plan.js
+++ b/netlify/functions/generate-meal-plan.js
@@ -1,12 +1,13 @@
 import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
 import { getAdminClient } from './_shared/supabase-admin.js';
-import { getAnthropic, loadPrompt, MODEL } from './_shared/anthropic.js';
+import { getAnthropic, loadPrompt } from './_shared/anthropic.js';
+import { resolveModelAndKey } from './_shared/tier.js';
 import { checkRateLimit } from './_shared/rate-limit.js';
 
 export const handler = async (event) => {
   if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' });
   try {
-    const { user, role } = await requireUser(event);
+    const { user, profile, role } = await requireUser(event);
     const body = JSON.parse(event.body || '{}');
 
     const targetClientId = body.clientId ?? user.id;
@@ -39,9 +40,10 @@ export const handler = async (event) => {
       profile: body.profile ?? null,
     };
 
-    const anthropic = getAnthropic();
+    const { model, apiKeyOverride } = resolveModelAndKey(profile);
+    const anthropic = getAnthropic(apiKeyOverride);
     const resp = await anthropic.messages.create({
-      model: MODEL,
+      model,
       max_tokens: 3000,
       system,
       messages: [{ role: 'user', content: JSON.stringify(input) }],

--- a/netlify/functions/generate-meal-plan.js
+++ b/netlify/functions/generate-meal-plan.js
@@ -11,11 +11,11 @@ export const handler = async (event) => {
     const body = JSON.parse(event.body || '{}');
 
     const targetClientId = body.clientId ?? user.id;
-    if (targetClientId !== user.id && role !== 'coach') {
+    if (targetClientId !== user.id && role !== 'coach' && role !== 'owner') {
       return jsonResponse(403, { error: 'Not permitted' });
     }
 
-    const limit = await checkRateLimit({
+    const limit = role === 'owner' ? { allowed: true } : await checkRateLimit({
       userId: user.id,
       bucket: 'generate-meal-plan',
       max: 10,
@@ -40,7 +40,7 @@ export const handler = async (event) => {
       profile: body.profile ?? null,
     };
 
-    const { model, apiKeyOverride } = resolveModelAndKey(profile);
+    const { model, apiKeyOverride } = resolveModelAndKey(profile, role);
     const anthropic = getAnthropic(apiKeyOverride);
     const resp = await anthropic.messages.create({
       model,

--- a/netlify/functions/generate-weekly-review.js
+++ b/netlify/functions/generate-weekly-review.js
@@ -1,6 +1,7 @@
 import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
 import { getAdminClient } from './_shared/supabase-admin.js';
-import { getAnthropic, loadPrompt, MODEL } from './_shared/anthropic.js';
+import { getAnthropic, loadPrompt } from './_shared/anthropic.js';
+import { resolveModelAndKey } from './_shared/tier.js';
 import { checkRateLimit } from './_shared/rate-limit.js';
 
 function startOfWeek(d = new Date()) {
@@ -122,9 +123,10 @@ export const handler = async (event) => {
     };
 
     const system = loadPrompt('pkfit-system.md') + '\n\n' + loadPrompt('weekly-review.md');
-    const anthropic = getAnthropic();
+    const { model, apiKeyOverride } = resolveModelAndKey(profile);
+    const anthropic = getAnthropic(apiKeyOverride);
     const resp = await anthropic.messages.create({
-      model: MODEL,
+      model,
       max_tokens: 1200,
       system,
       messages: [{ role: 'user', content: JSON.stringify(input) }],

--- a/netlify/functions/generate-weekly-review.js
+++ b/netlify/functions/generate-weekly-review.js
@@ -19,11 +19,11 @@ export const handler = async (event) => {
     const { user, role } = await requireUser(event);
     const body = JSON.parse(event.body || '{}');
     const targetClientId = body.clientId ?? user.id;
-    if (targetClientId !== user.id && role !== 'coach') {
+    if (targetClientId !== user.id && role !== 'coach' && role !== 'owner') {
       return jsonResponse(403, { error: 'Not permitted' });
     }
 
-    const limit = await checkRateLimit({
+    const limit = role === 'owner' ? { allowed: true } : await checkRateLimit({
       userId: user.id,
       bucket: 'generate-weekly-review',
       max: 5,
@@ -123,7 +123,7 @@ export const handler = async (event) => {
     };
 
     const system = loadPrompt('pkfit-system.md') + '\n\n' + loadPrompt('weekly-review.md');
-    const { model, apiKeyOverride } = resolveModelAndKey(profile);
+    const { model, apiKeyOverride } = resolveModelAndKey(profile, role);
     const anthropic = getAnthropic(apiKeyOverride);
     const resp = await anthropic.messages.create({
       model,

--- a/netlify/functions/generate-workout.js
+++ b/netlify/functions/generate-workout.js
@@ -11,12 +11,12 @@ export const handler = async (event) => {
     const body = JSON.parse(event.body || '{}');
 
     const targetClientId = body.clientId ?? user.id;
-    // Only the client themself or a coach can generate for a client.
-    if (targetClientId !== user.id && role !== 'coach') {
+    // Only the client themself, a coach, or the owner can generate for a client.
+    if (targetClientId !== user.id && role !== 'coach' && role !== 'owner') {
       return jsonResponse(403, { error: 'Not permitted' });
     }
 
-    const limit = await checkRateLimit({
+    const limit = role === 'owner' ? { allowed: true } : await checkRateLimit({
       userId: user.id,
       bucket: 'generate-workout',
       max: 10,
@@ -40,7 +40,7 @@ export const handler = async (event) => {
       profile: body.profile ?? null,
     };
 
-    const { model, apiKeyOverride } = resolveModelAndKey(profile);
+    const { model, apiKeyOverride } = resolveModelAndKey(profile, role);
     const anthropic = getAnthropic(apiKeyOverride);
     const resp = await anthropic.messages.create({
       model,

--- a/netlify/functions/generate-workout.js
+++ b/netlify/functions/generate-workout.js
@@ -1,12 +1,13 @@
 import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
 import { getAdminClient } from './_shared/supabase-admin.js';
-import { getAnthropic, loadPrompt, MODEL } from './_shared/anthropic.js';
+import { getAnthropic, loadPrompt } from './_shared/anthropic.js';
+import { resolveModelAndKey } from './_shared/tier.js';
 import { checkRateLimit } from './_shared/rate-limit.js';
 
 export const handler = async (event) => {
   if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' });
   try {
-    const { user, role } = await requireUser(event);
+    const { user, profile, role } = await requireUser(event);
     const body = JSON.parse(event.body || '{}');
 
     const targetClientId = body.clientId ?? user.id;
@@ -39,9 +40,10 @@ export const handler = async (event) => {
       profile: body.profile ?? null,
     };
 
-    const anthropic = getAnthropic();
+    const { model, apiKeyOverride } = resolveModelAndKey(profile);
+    const anthropic = getAnthropic(apiKeyOverride);
     const resp = await anthropic.messages.create({
-      model: MODEL,
+      model,
       max_tokens: 2048,
       system,
       messages: [{ role: 'user', content: JSON.stringify(input) }],

--- a/netlify/functions/get-my-medical.js
+++ b/netlify/functions/get-my-medical.js
@@ -1,0 +1,28 @@
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { getAdminClient } from './_shared/supabase-admin.js';
+import { decryptMedical } from './_shared/medical-crypto.js';
+
+// Returns the decrypted medical block for the authenticated user. The owner
+// can also request another user's medical via ?clientId= (used for coach
+// surfaces); that branch is intentionally NOT enabled in v1 — coach UI
+// reads via dedicated coach functions, never this one.
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'GET' && event.httpMethod !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+  try {
+    const { user } = await requireUser(event);
+    const admin = getAdminClient();
+    const { data, error } = await admin
+      .from('profiles')
+      .select('medical_encrypted')
+      .eq('id', user.id)
+      .maybeSingle();
+    if (error) return jsonResponse(500, { error: error.message });
+    const medical = decryptMedical(data?.medical_encrypted);
+    return jsonResponse(200, { medical: medical ?? null });
+  } catch (e) {
+    return errorResponse(e);
+  }
+};

--- a/netlify/functions/save-byo-key.js
+++ b/netlify/functions/save-byo-key.js
@@ -1,0 +1,50 @@
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { getAdminClient } from './_shared/supabase-admin.js';
+import { tierFromProfile } from './_shared/tier.js';
+import { encryptByoKey } from './_shared/byo-crypto.js';
+
+// Tier 3 subscribers can paste an Anthropic API key. The server encrypts it
+// AES-256-GCM with BYO_KEY_SECRET and stores the ciphertext on the profile.
+// Subsequent generator/assistant calls will decrypt it per-request and use
+// it as `apiKeyOverride` to Anthropic's SDK — meaning the user's own key
+// pays for tokens, while PKFIT keeps the subscription margin.
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST' && event.httpMethod !== 'DELETE') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+  try {
+    const { user, profile } = await requireUser(event);
+
+    if (tierFromProfile(profile) !== 'tier3') {
+      return jsonResponse(403, { error: 'BYO key is a tier3 feature' });
+    }
+
+    const admin = getAdminClient();
+
+    if (event.httpMethod === 'DELETE') {
+      const { error } = await admin
+        .from('profiles')
+        .update({ byo_anthropic_key_encrypted: null })
+        .eq('id', user.id);
+      if (error) return jsonResponse(500, { error: error.message });
+      return jsonResponse(200, { ok: true, cleared: true });
+    }
+
+    const { apiKey } = JSON.parse(event.body || '{}');
+    if (typeof apiKey !== 'string' || !apiKey.startsWith('sk-ant-')) {
+      return jsonResponse(400, { error: 'Provide an Anthropic API key (sk-ant-...)' });
+    }
+
+    const encrypted = encryptByoKey(apiKey.trim());
+    const { error } = await admin
+      .from('profiles')
+      .update({ byo_anthropic_key_encrypted: encrypted })
+      .eq('id', user.id);
+    if (error) return jsonResponse(500, { error: error.message });
+
+    return jsonResponse(200, { ok: true });
+  } catch (e) {
+    return errorResponse(e);
+  }
+};

--- a/netlify/functions/stripe-webhook.js
+++ b/netlify/functions/stripe-webhook.js
@@ -13,14 +13,22 @@ function mapStatus(s) {
 
 function tierFromPriceId(priceId) {
   const map = {
-    [process.env.STRIPE_PRICE_PERFORMANCE_MONTHLY]: 'performance',
-    [process.env.STRIPE_PRICE_PERFORMANCE_ANNUAL]: 'performance',
-    [process.env.STRIPE_PRICE_IDENTITY_MONTHLY]: 'identity',
-    [process.env.STRIPE_PRICE_IDENTITY_ANNUAL]: 'identity',
-    [process.env.STRIPE_PRICE_FULL_MONTHLY]: 'full',
-    [process.env.STRIPE_PRICE_FULL_ANNUAL]: 'full',
-    [process.env.STRIPE_PRICE_PREMIUM_MONTHLY]: 'premium',
-    [process.env.STRIPE_PRICE_PREMIUM_ANNUAL]: 'premium',
+    [process.env.STRIPE_PRICE_TIER1_MONTHLY]: 'tier1',
+    [process.env.STRIPE_PRICE_TIER1_ANNUAL]: 'tier1',
+    [process.env.STRIPE_PRICE_TIER2_MONTHLY]: 'tier2',
+    [process.env.STRIPE_PRICE_TIER2_ANNUAL]: 'tier2',
+    [process.env.STRIPE_PRICE_TIER3_MONTHLY]: 'tier3',
+    [process.env.STRIPE_PRICE_TIER3_ANNUAL]: 'tier3',
+    // Legacy price IDs map to the new tier they roll up to. Retained so
+    // already-active subscriptions keep resolving until they renew.
+    [process.env.STRIPE_PRICE_PERFORMANCE_MONTHLY]: 'tier1',
+    [process.env.STRIPE_PRICE_PERFORMANCE_ANNUAL]: 'tier1',
+    [process.env.STRIPE_PRICE_IDENTITY_MONTHLY]: 'tier1',
+    [process.env.STRIPE_PRICE_IDENTITY_ANNUAL]: 'tier1',
+    [process.env.STRIPE_PRICE_FULL_MONTHLY]: 'tier2',
+    [process.env.STRIPE_PRICE_FULL_ANNUAL]: 'tier2',
+    [process.env.STRIPE_PRICE_PREMIUM_MONTHLY]: 'tier3',
+    [process.env.STRIPE_PRICE_PREMIUM_ANNUAL]: 'tier3',
   };
   return map[priceId] ?? null;
 }

--- a/netlify/functions/update-profile.js
+++ b/netlify/functions/update-profile.js
@@ -1,0 +1,94 @@
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { getAdminClient } from './_shared/supabase-admin.js';
+import { encryptMedical } from './_shared/medical-crypto.js';
+
+// Single endpoint for writing the intake / medical / consent / name fields
+// on a profile row. Medical is encrypted at this boundary so the column
+// never holds plaintext.
+
+const TEXT_LIMIT = 200;
+const NOTE_LIMIT = 2000;
+
+function sanitize(s, max = TEXT_LIMIT) {
+  if (typeof s !== 'string') return null;
+  return s.trim().slice(0, max) || null;
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') return jsonResponse(405, { error: 'Method not allowed' });
+  try {
+    const { user } = await requireUser(event);
+    const body = JSON.parse(event.body || '{}');
+
+    const updates = {};
+
+    if (body.name !== undefined) {
+      const name = sanitize(body.name);
+      if (name) updates.name = name;
+    }
+
+    if (body.intake && typeof body.intake === 'object') {
+      // Whitelist keys so a malformed POST can't smuggle arbitrary blobs.
+      const i = body.intake;
+      updates.intake = {
+        legal_name: sanitize(i.legal_name),
+        address_line1: sanitize(i.address_line1),
+        address_line2: sanitize(i.address_line2),
+        city: sanitize(i.city),
+        state: sanitize(i.state, 4),
+        postal_code: sanitize(i.postal_code, 12),
+        country: sanitize(i.country, 4) ?? 'US',
+        dob: sanitize(i.dob, 12),
+        sex: sanitize(i.sex, 12),
+        height_cm: typeof i.height_cm === 'number' ? i.height_cm : null,
+        weight_lb: typeof i.weight_lb === 'number' ? i.weight_lb : null,
+        occupation: sanitize(i.occupation),
+        training_background: sanitize(i.training_background, NOTE_LIMIT),
+        goals: sanitize(i.goals, NOTE_LIMIT),
+        training_days_per_week: typeof i.training_days_per_week === 'number' ? i.training_days_per_week : null,
+        equipment: sanitize(i.equipment, NOTE_LIMIT),
+      };
+    }
+
+    if (body.medical && typeof body.medical === 'object') {
+      const m = body.medical;
+      const cleaned = {
+        conditions: sanitize(m.conditions, NOTE_LIMIT),
+        medications: sanitize(m.medications, NOTE_LIMIT),
+        allergies: sanitize(m.allergies, NOTE_LIMIT),
+        injuries: sanitize(m.injuries, NOTE_LIMIT),
+        emergency_contact: m.emergency_contact && typeof m.emergency_contact === 'object'
+          ? {
+              name: sanitize(m.emergency_contact.name),
+              phone: sanitize(m.emergency_contact.phone, 30),
+              relation: sanitize(m.emergency_contact.relation, 40),
+            }
+          : null,
+      };
+      updates.medical_encrypted = encryptMedical(cleaned);
+    }
+
+    if (body.consent && typeof body.consent === 'object') {
+      const c = body.consent;
+      updates.consent = {
+        tos_v: Number(c.tos_v) || null,
+        coaching_v: Number(c.coaching_v) || null,
+        privacy_v: Number(c.privacy_v) || null,
+        signed_at: new Date().toISOString(),
+        ua: sanitize(event.headers?.['user-agent'] ?? '', 300),
+      };
+    }
+
+    if (Object.keys(updates).length === 0) {
+      return jsonResponse(400, { error: 'Nothing to update' });
+    }
+
+    const admin = getAdminClient();
+    const { error } = await admin.from('profiles').update(updates).eq('id', user.id);
+    if (error) return jsonResponse(500, { error: error.message });
+
+    return jsonResponse(200, { ok: true });
+  } catch (e) {
+    return errorResponse(e);
+  }
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "packages/*"
       ],
       "dependencies": {
+        "@google/generative-ai": "^0.24.1",
         "@pkfit/ui": "*",
         "@stripe/stripe-js": "^4.8.0",
         "@supabase/supabase-js": "^2.45.4",
@@ -943,6 +944,15 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@google/generative-ai": {
+      "version": "0.24.1",
+      "resolved": "https://registry.npmjs.org/@google/generative-ai/-/generative-ai-0.24.1.tgz",
+      "integrity": "sha512-MqO+MLfM6kjxcKoy0p1wRzG3b4ZZXtPI+z2IE26UogS2Cm/XHO+7gGRBh6gcJsOiIVoH93UwKvW4HdgiOZCy9Q==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@humanfs/core": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@pkfit/ui": "*",
         "@stripe/stripe-js": "^4.8.0",
         "@supabase/supabase-js": "^2.45.4",
+        "framer-motion": "^11.18.2",
         "lucide-react": "^0.454.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -3761,6 +3762,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -5196,6 +5224,21 @@
       "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/motion-dom": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
       "license": "MIT"
     },
     "node_modules/ms": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "axiom:smoke": "node scripts/axiom-smoke.js"
   },
   "dependencies": {
+    "@google/generative-ai": "^0.24.1",
     "@pkfit/ui": "*",
     "@stripe/stripe-js": "^4.8.0",
     "@supabase/supabase-js": "^2.45.4",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@pkfit/ui": "*",
     "@stripe/stripe-js": "^4.8.0",
     "@supabase/supabase-js": "^2.45.4",
+    "framer-motion": "^11.18.2",
     "lucide-react": "^0.454.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/scripts/generate-trailer.js
+++ b/scripts/generate-trailer.js
@@ -8,7 +8,7 @@
 // asset is served directly from /trailer/pkfit-intro.mp4.
 //
 // Usage:
-//   FAL_KEY=fal_xxx node scripts/generate-trailer.js
+//   FAL_API_KEY=fal_xxx node scripts/generate-trailer.js
 //
 // Optional overrides:
 //   FAL_VIDEO_MODEL=fal-ai/veo3        # default
@@ -34,9 +34,9 @@ const DEFAULT_PROMPT = [
 ].join(' ');
 
 async function main() {
-  const apiKey = process.env.FAL_KEY;
+  const apiKey = process.env.FAL_API_KEY ?? process.env.FAL_KEY;
   if (!apiKey) {
-    console.error('FAL_KEY env var is required.');
+    console.error('FAL_API_KEY env var is required.');
     process.exit(1);
   }
   const model = process.env.FAL_VIDEO_MODEL || 'fal-ai/veo3';

--- a/scripts/generate-trailer.js
+++ b/scripts/generate-trailer.js
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+//
+// One-shot generator for the cinematic landing trailer.
+//
+// Calls fal.ai's video model with a PKFIT brand prompt, polls for completion,
+// downloads the resulting mp4 to public/trailer/pkfit-intro.mp4. Re-run to
+// regenerate; the runtime never calls fal.ai for the trailer — the static
+// asset is served directly from /trailer/pkfit-intro.mp4.
+//
+// Usage:
+//   FAL_KEY=fal_xxx node scripts/generate-trailer.js
+//
+// Optional overrides:
+//   FAL_VIDEO_MODEL=fal-ai/veo3        # default
+//   TRAILER_PROMPT="..."               # override the default brand prompt
+
+import { mkdir, writeFile } from 'node:fs/promises';
+import { existsSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(HERE, '..');
+const OUT_DIR = resolve(PROJECT_ROOT, 'public', 'trailer');
+const OUT_FILE = resolve(OUT_DIR, 'pkfit-intro.mp4');
+
+const DEFAULT_PROMPT = [
+  'Cinematic 8-second intro for the PKFIT coaching brand.',
+  'Pure black background. A single bar of warm gold (#C9A84C) pulses once,',
+  'expanding into the wordmark "PKFIT" rendered in Bebas Neue, all caps,',
+  'high contrast, slight grain. Beneath it, the line "Powered by /operate/axiom"',
+  'fades in in monospace. Slow dolly forward, depth of field, no people, no logos.',
+  'Tone: surgical, restrained, premium. No emoji. No motion blur. No text glitches.',
+].join(' ');
+
+async function main() {
+  const apiKey = process.env.FAL_KEY;
+  if (!apiKey) {
+    console.error('FAL_KEY env var is required.');
+    process.exit(1);
+  }
+  const model = process.env.FAL_VIDEO_MODEL || 'fal-ai/veo3';
+  const prompt = process.env.TRAILER_PROMPT || DEFAULT_PROMPT;
+
+  if (!existsSync(OUT_DIR)) {
+    await mkdir(OUT_DIR, { recursive: true });
+  }
+
+  console.log(`[trailer] submitting to ${model}...`);
+  const submit = await fetch(`https://queue.fal.run/${model}`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Key ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ prompt, duration: 8, aspect_ratio: '16:9' }),
+  });
+  if (!submit.ok) {
+    console.error(`[trailer] submit failed: ${submit.status} ${await submit.text()}`);
+    process.exit(2);
+  }
+  const submitJson = await submit.json();
+  const requestId = submitJson.request_id;
+  if (!requestId) {
+    console.error(`[trailer] no request_id in response: ${JSON.stringify(submitJson)}`);
+    process.exit(2);
+  }
+
+  const statusUrl = `https://queue.fal.run/${model}/requests/${requestId}/status`;
+  const resultUrl = `https://queue.fal.run/${model}/requests/${requestId}`;
+
+  for (let i = 0; i < 60; i += 1) {
+    await new Promise((r) => setTimeout(r, 5000));
+    const s = await fetch(statusUrl, { headers: { Authorization: `Key ${apiKey}` } });
+    const sj = await s.json();
+    console.log(`[trailer] status: ${sj.status}`);
+    if (sj.status === 'COMPLETED') break;
+    if (sj.status === 'FAILED' || sj.status === 'ERROR') {
+      console.error(`[trailer] generation failed: ${JSON.stringify(sj)}`);
+      process.exit(3);
+    }
+  }
+
+  const r = await fetch(resultUrl, { headers: { Authorization: `Key ${apiKey}` } });
+  const result = await r.json();
+  const videoUrl = result?.video?.url ?? result?.output?.video?.url ?? result?.url;
+  if (!videoUrl) {
+    console.error(`[trailer] no video URL in result: ${JSON.stringify(result)}`);
+    process.exit(4);
+  }
+
+  console.log(`[trailer] downloading from ${videoUrl}`);
+  const v = await fetch(videoUrl);
+  if (!v.ok) {
+    console.error(`[trailer] download failed: ${v.status}`);
+    process.exit(5);
+  }
+  const buf = Buffer.from(await v.arrayBuffer());
+  await writeFile(OUT_FILE, buf);
+  console.log(`[trailer] wrote ${OUT_FILE} (${buf.length} bytes)`);
+  console.log('[trailer] commit public/trailer/pkfit-intro.mp4 to ship the asset.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(99);
+});

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,6 +4,7 @@ import { ProtectedRoute } from './components/ProtectedRoute';
 import { RequiresActiveSubscription } from './components/RequiresActiveSubscription';
 
 import Landing from './pages/Landing.jsx';
+import HomeScreen from './pages/HomeScreen.jsx';
 import Splash from './pages/Splash.jsx';
 import Onboarding from './pages/Onboarding.jsx';
 import NotFound from './pages/NotFound.jsx';
@@ -50,7 +51,20 @@ export default function App() {
       <Route path="/onboarding" element={<Onboarding />} />
       <Route path="/migrate/:token" element={<Migrate />} />
 
-      {/* Client-protected */}
+      {/* iPhone-style home screen — outside the Layout chrome so it occupies
+          the full viewport with its own dock. Still gated by auth + active
+          subscription. */}
+      <Route
+        element={
+          <ProtectedRoute role="client">
+            <RequiresActiveSubscription />
+          </ProtectedRoute>
+        }
+      >
+        <Route path="/home" element={<HomeScreen />} />
+      </Route>
+
+      {/* Client-protected (with sidebar/dock chrome) */}
       <Route
         element={
           <ProtectedRoute role="client">

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { RequiresActiveSubscription } from './components/RequiresActiveSubscript
 
 import Landing from './pages/Landing.jsx';
 import HomeScreen from './pages/HomeScreen.jsx';
+import Owner from './pages/Owner.jsx';
 import Splash from './pages/Splash.jsx';
 import Onboarding from './pages/Onboarding.jsx';
 import NotFound from './pages/NotFound.jsx';
@@ -63,6 +64,18 @@ export default function App() {
       >
         <Route path="/home" element={<HomeScreen />} />
       </Route>
+
+      {/* Owner panel — only matters if the signed-in user's email is in
+          OWNER_EMAILS server-side. The page itself enforces, so any client
+          that sneaks here just sees the "Owner only" message. */}
+      <Route
+        path="/owner"
+        element={
+          <ProtectedRoute>
+            <Owner />
+          </ProtectedRoute>
+        }
+      />
 
       {/* Client-protected (with sidebar/dock chrome) */}
       <Route

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import { RequiresActiveSubscription } from './components/RequiresActiveSubscript
 import Landing from './pages/Landing.jsx';
 import HomeScreen from './pages/HomeScreen.jsx';
 import Owner from './pages/Owner.jsx';
+import ImageLab from './pages/owner/ImageLab.jsx';
 import Splash from './pages/Splash.jsx';
 import Terms from './pages/legal/Terms.jsx';
 import CoachingAgreement from './pages/legal/Coaching.jsx';
@@ -80,6 +81,14 @@ export default function App() {
         element={
           <ProtectedRoute>
             <Owner />
+          </ProtectedRoute>
+        }
+      />
+      <Route
+        path="/owner/images"
+        element={
+          <ProtectedRoute>
+            <ImageLab />
           </ProtectedRoute>
         }
       />

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -7,6 +7,10 @@ import Landing from './pages/Landing.jsx';
 import HomeScreen from './pages/HomeScreen.jsx';
 import Owner from './pages/Owner.jsx';
 import Splash from './pages/Splash.jsx';
+import Terms from './pages/legal/Terms.jsx';
+import CoachingAgreement from './pages/legal/Coaching.jsx';
+import Privacy from './pages/legal/Privacy.jsx';
+import Import from './pages/client/Import.jsx';
 import Onboarding from './pages/Onboarding.jsx';
 import NotFound from './pages/NotFound.jsx';
 import Migrate from './pages/Migrate.jsx';
@@ -51,6 +55,9 @@ export default function App() {
       <Route path="/signup" element={<Signup />} />
       <Route path="/onboarding" element={<Onboarding />} />
       <Route path="/migrate/:token" element={<Migrate />} />
+      <Route path="/legal/terms" element={<Terms />} />
+      <Route path="/legal/coaching" element={<CoachingAgreement />} />
+      <Route path="/legal/privacy" element={<Privacy />} />
 
       {/* iPhone-style home screen — outside the Layout chrome so it occupies
           the full viewport with its own dock. Still gated by auth + active
@@ -105,6 +112,7 @@ export default function App() {
         <Route path="/billing" element={<Billing />} />
         <Route path="/profile" element={<Profile />} />
         <Route path="/settings" element={<Settings />} />
+        <Route path="/import" element={<Import />} />
       </Route>
 
       {/* Coach-protected */}

--- a/src/components/CinematicIntro.jsx
+++ b/src/components/CinematicIntro.jsx
@@ -1,0 +1,121 @@
+import { useEffect, useRef, useState } from 'react';
+import { AnimatePresence, motion } from 'framer-motion';
+
+// Cinematic intro shown on first visit to Landing (or when manually replayed).
+//
+// Behavior:
+//   - If /trailer/pkfit-intro.mp4 is present, plays it muted/inline. Otherwise
+//     falls back to a CSS/Framer typography reveal so the page never blocks
+//     waiting for an asset that hasn't been generated yet.
+//   - Skippable (button + tap-to-skip). Auto-dismisses on `ended` or after the
+//     8s fallback completes.
+//   - Sets `localStorage.pkfit_intro_seen = "1"` so subsequent visits skip.
+//
+// Generate the real video via `node scripts/generate-trailer.js` (one-shot,
+// fal.ai veo). Output goes to public/trailer/pkfit-intro.mp4 + poster.jpg and
+// is committed as a static asset — runtime never calls fal.ai.
+
+const SEEN_KEY = 'pkfit_intro_seen';
+
+export function CinematicIntro({ onDone, force = false }) {
+  const [visible, setVisible] = useState(() => {
+    if (force) return true;
+    if (typeof window === 'undefined') return false;
+    return window.localStorage.getItem(SEEN_KEY) !== '1';
+  });
+  const [videoFailed, setVideoFailed] = useState(false);
+  const videoRef = useRef(null);
+
+  useEffect(() => {
+    if (!visible) return undefined;
+    if (videoFailed) {
+      const t = setTimeout(() => dismiss(), 6500);
+      return () => clearTimeout(t);
+    }
+    const v = videoRef.current;
+    if (!v) return undefined;
+    const onErr = () => setVideoFailed(true);
+    v.addEventListener('error', onErr);
+    return () => v.removeEventListener('error', onErr);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visible, videoFailed]);
+
+  function dismiss() {
+    if (typeof window !== 'undefined') {
+      window.localStorage.setItem(SEEN_KEY, '1');
+    }
+    setVisible(false);
+    onDone?.();
+  }
+
+  if (!visible) return null;
+
+  return (
+    <AnimatePresence>
+      <motion.div
+        key="cinematic"
+        className="fixed inset-0 z-[100] flex items-center justify-center bg-bg"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={{ opacity: 0 }}
+        transition={{ duration: 0.6 }}
+        role="dialog"
+        aria-label="PKFIT intro"
+      >
+        {!videoFailed ? (
+          <video
+            ref={videoRef}
+            className="h-full w-full object-cover"
+            autoPlay
+            muted
+            playsInline
+            preload="auto"
+            poster="/trailer/poster.jpg"
+            onEnded={dismiss}
+          >
+            <source src="/trailer/pkfit-intro.mp4" type="video/mp4" />
+          </video>
+        ) : (
+          <FallbackReveal />
+        )}
+
+        <button
+          type="button"
+          onClick={dismiss}
+          className="absolute bottom-8 right-8 border border-line/40 bg-black/40 px-4 py-2 text-[0.7rem] uppercase tracking-widest2 text-mute backdrop-blur transition-colors hover:border-gold hover:text-gold"
+        >
+          Skip
+        </button>
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+
+function FallbackReveal() {
+  return (
+    <div className="pointer-events-none flex flex-col items-center">
+      <motion.div
+        className="font-display text-[clamp(4rem,14vw,11rem)] leading-none tracking-wider2 text-gold"
+        initial={{ opacity: 0, letterSpacing: '0.4em' }}
+        animate={{ opacity: 1, letterSpacing: '0.08em' }}
+        transition={{ duration: 1.6, ease: [0.2, 0.6, 0.2, 1] }}
+      >
+        PKFIT
+      </motion.div>
+      <motion.div
+        className="mt-3 h-px w-32 bg-gold"
+        initial={{ scaleX: 0 }}
+        animate={{ scaleX: [0, 1, 1, 0] }}
+        transition={{ duration: 4, ease: 'easeInOut', times: [0, 0.4, 0.7, 1] }}
+      />
+      <motion.div
+        className="mt-4 text-[0.7rem] uppercase tracking-widest2 text-mute"
+        initial={{ opacity: 0 }}
+        animate={{ opacity: [0, 1, 1, 0] }}
+        transition={{ duration: 4, delay: 1.2, times: [0, 0.3, 0.7, 1] }}
+      >
+        Powered by /operate/axiom
+      </motion.div>
+    </div>
+  );
+}

--- a/src/components/IntakePanel.jsx
+++ b/src/components/IntakePanel.jsx
@@ -1,0 +1,259 @@
+import { useEffect, useState } from 'react';
+import { ShieldCheck } from 'lucide-react';
+import { profileApi } from '../lib/claudeClient';
+import { feetInchesToCm, cmToFeetInches } from '../lib/units';
+import { Button } from './ui/Button';
+import { Input } from './ui/Input';
+
+// Full intake panel: legal name, address, DOB, sex, height (ft + in),
+// weight (lb), occupation, training background, goals — plus encrypted
+// medical block (conditions, meds, allergies, injuries, emergency contact).
+//
+// Reads intake directly from the loaded profile prop. Reads medical via
+// /get-my-medical (server decrypts). Writes via /update-profile (server
+// encrypts medical before storing).
+
+const SEX_OPTIONS = ['', 'male', 'female', 'prefer_not_to_say'];
+
+function emptyIntake() {
+  return {
+    legal_name: '',
+    address_line1: '',
+    address_line2: '',
+    city: '',
+    state: '',
+    postal_code: '',
+    country: 'US',
+    dob: '',
+    sex: '',
+    height_ft: '',
+    height_in: '',
+    weight_lb: '',
+    occupation: '',
+    training_background: '',
+    goals: '',
+    training_days_per_week: '',
+    equipment: '',
+  };
+}
+
+function emptyMedical() {
+  return {
+    conditions: '',
+    medications: '',
+    allergies: '',
+    injuries: '',
+    emergency_name: '',
+    emergency_phone: '',
+    emergency_relation: '',
+  };
+}
+
+export function IntakePanel({ profile }) {
+  const [intake, setIntake] = useState(emptyIntake);
+  const [medical, setMedical] = useState(emptyMedical);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState(null);
+  const [savedAt, setSavedAt] = useState(null);
+  const [medicalLoaded, setMedicalLoaded] = useState(false);
+
+  useEffect(() => {
+    const i = profile?.intake ?? {};
+    const fi = i.height_cm != null ? cmToFeetInches(i.height_cm) : null;
+    setIntake({
+      ...emptyIntake(),
+      ...i,
+      height_ft: fi?.feet ?? '',
+      height_in: fi?.inches ?? '',
+      weight_lb: i.weight_lb ?? '',
+      training_days_per_week: i.training_days_per_week ?? '',
+    });
+  }, [profile?.intake]);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { medical: m } = await profileApi.getMedical();
+        if (cancelled) return;
+        if (m) {
+          setMedical({
+            conditions: m.conditions ?? '',
+            medications: m.medications ?? '',
+            allergies: m.allergies ?? '',
+            injuries: m.injuries ?? '',
+            emergency_name: m.emergency_contact?.name ?? '',
+            emergency_phone: m.emergency_contact?.phone ?? '',
+            emergency_relation: m.emergency_contact?.relation ?? '',
+          });
+        }
+        setMedicalLoaded(true);
+      } catch {
+        setMedicalLoaded(true);
+      }
+    })();
+    return () => { cancelled = true; };
+  }, []);
+
+  function bind(group, key) {
+    const setter = group === 'intake' ? setIntake : setMedical;
+    const value = (group === 'intake' ? intake : medical)[key] ?? '';
+    return {
+      value,
+      onChange: (e) => setter((s) => ({ ...s, [key]: e.target.value })),
+    };
+  }
+
+  async function save(e) {
+    e.preventDefault();
+    setBusy(true);
+    setErr(null);
+    try {
+      const payload = {
+        intake: {
+          legal_name: intake.legal_name || null,
+          address_line1: intake.address_line1 || null,
+          address_line2: intake.address_line2 || null,
+          city: intake.city || null,
+          state: intake.state || null,
+          postal_code: intake.postal_code || null,
+          country: intake.country || 'US',
+          dob: intake.dob || null,
+          sex: intake.sex || null,
+          height_cm: feetInchesToCm(intake.height_ft, intake.height_in),
+          weight_lb: intake.weight_lb ? Number(intake.weight_lb) : null,
+          occupation: intake.occupation || null,
+          training_background: intake.training_background || null,
+          goals: intake.goals || null,
+          training_days_per_week: intake.training_days_per_week ? Number(intake.training_days_per_week) : null,
+          equipment: intake.equipment || null,
+        },
+        medical: {
+          conditions: medical.conditions || null,
+          medications: medical.medications || null,
+          allergies: medical.allergies || null,
+          injuries: medical.injuries || null,
+          emergency_contact: {
+            name: medical.emergency_name || null,
+            phone: medical.emergency_phone || null,
+            relation: medical.emergency_relation || null,
+          },
+        },
+      };
+      await profileApi.update(payload);
+      setSavedAt(new Date());
+    } catch (e) {
+      setErr(e.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={save} className="space-y-8 border border-line bg-black/20 p-5">
+      <header>
+        <div className="label mb-1">Intake</div>
+        <h2 className="font-display text-2xl tracking-wider2 text-ink">
+          Personal record
+        </h2>
+        <p className="mt-2 text-xs text-mute">
+          American units throughout. Medical fields are encrypted at rest with a
+          server-side key. Visible only to you and the coach.
+        </p>
+      </header>
+
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        <Input label="Legal name" {...bind('intake', 'legal_name')} />
+        <Input label="Date of birth (YYYY-MM-DD)" type="date" {...bind('intake', 'dob')} />
+        <Input label="Address line 1" {...bind('intake', 'address_line1')} />
+        <Input label="Address line 2" {...bind('intake', 'address_line2')} />
+        <Input label="City" {...bind('intake', 'city')} />
+        <Input label="State" maxLength={4} placeholder="TX" {...bind('intake', 'state')} />
+        <Input label="ZIP" maxLength={12} {...bind('intake', 'postal_code')} />
+        <label className="flex flex-col gap-1">
+          <span className="label">Sex</span>
+          <select
+            value={intake.sex}
+            onChange={(e) => setIntake((s) => ({ ...s, sex: e.target.value }))}
+            className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+          >
+            {SEX_OPTIONS.map((v) => (
+              <option key={v || 'none'} value={v}>
+                {v || 'Select'}
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="grid grid-cols-2 gap-2">
+          <Input label="Height (ft)" type="number" min="3" max="8" {...bind('intake', 'height_ft')} />
+          <Input label="Height (in)" type="number" min="0" max="11" {...bind('intake', 'height_in')} />
+        </div>
+        <Input label="Weight (lb)" type="number" min="50" max="800" step="0.1" {...bind('intake', 'weight_lb')} />
+        <Input label="Occupation" {...bind('intake', 'occupation')} />
+        <Input label="Training days/week" type="number" min="1" max="7" {...bind('intake', 'training_days_per_week')} />
+      </section>
+
+      <section className="space-y-3">
+        <Input label="Equipment access (gym, home rack, dumbbells…)" {...bind('intake', 'equipment')} />
+        <label className="flex flex-col gap-1">
+          <span className="label">Training background</span>
+          <textarea
+            rows={3}
+            value={intake.training_background}
+            onChange={(e) => setIntake((s) => ({ ...s, training_background: e.target.value }))}
+            className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+          />
+        </label>
+        <label className="flex flex-col gap-1">
+          <span className="label">Goals</span>
+          <textarea
+            rows={3}
+            value={intake.goals}
+            onChange={(e) => setIntake((s) => ({ ...s, goals: e.target.value }))}
+            className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+          />
+        </label>
+      </section>
+
+      <section className="space-y-3 border-t border-line pt-6">
+        <header className="flex items-center gap-2">
+          <ShieldCheck size={14} className="text-gold" />
+          <div>
+            <div className="label">Medical (encrypted)</div>
+            <p className="text-xs text-mute">
+              {medicalLoaded ? 'AES-256-GCM at rest. Decrypted only for you.' : 'Loading…'}
+            </p>
+          </div>
+        </header>
+        {['conditions', 'medications', 'allergies', 'injuries'].map((k) => (
+          <label key={k} className="flex flex-col gap-1">
+            <span className="label capitalize">{k}</span>
+            <textarea
+              rows={2}
+              value={medical[k]}
+              onChange={(e) => setMedical((s) => ({ ...s, [k]: e.target.value }))}
+              className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+            />
+          </label>
+        ))}
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <Input label="Emergency contact name" {...bind('medical', 'emergency_name')} />
+          <Input label="Phone" type="tel" {...bind('medical', 'emergency_phone')} />
+          <Input label="Relation" {...bind('medical', 'emergency_relation')} />
+        </div>
+      </section>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Button disabled={busy}>{busy ? 'Saving' : 'Save intake'}</Button>
+        {savedAt ? (
+          <span className="text-[0.65rem] uppercase tracking-widest2 text-success">
+            Saved {savedAt.toLocaleTimeString()}
+          </span>
+        ) : null}
+        {err ? (
+          <span role="alert" className="text-xs uppercase tracking-widest2 text-signal">{err}</span>
+        ) : null}
+      </div>
+    </form>
+  );
+}

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -136,7 +136,7 @@ export function Layout() {
       <header className="border-b border-line bg-bg/90 backdrop-blur">
         <div className="mx-auto flex max-w-6xl items-center justify-between px-5 py-4">
           <NavLink
-            to={role === 'coach' ? '/coach' : '/dashboard'}
+            to={role === 'coach' ? '/coach' : '/home'}
             className="font-display text-2xl tracking-wider2 text-gold"
           >
             PKFIT

--- a/src/components/MarkdownDoc.jsx
+++ b/src/components/MarkdownDoc.jsx
@@ -1,0 +1,73 @@
+// Tiny markdown renderer for the legal pages. Handles only what the legal
+// docs use: # / ## / ### headings, paragraphs, ordered/unordered lists,
+// bold via **text**, and inline links. Avoids pulling a full markdown lib
+// into the bundle.
+
+function renderInline(text) {
+  // **bold**
+  const parts = [];
+  let last = 0;
+  const re = /\*\*([^*]+)\*\*/g;
+  let m;
+  while ((m = re.exec(text)) !== null) {
+    if (m.index > last) parts.push(text.slice(last, m.index));
+    parts.push(<strong key={m.index} className="text-ink">{m[1]}</strong>);
+    last = m.index + m[0].length;
+  }
+  if (last < text.length) parts.push(text.slice(last));
+  return parts;
+}
+
+export function MarkdownDoc({ source }) {
+  if (!source) return null;
+  const blocks = source.split(/\n{2,}/);
+  return (
+    <article className="space-y-4 text-sm text-mute">
+      {blocks.map((block, i) => {
+        const trimmed = block.trim();
+        if (!trimmed) return null;
+        if (trimmed.startsWith('### ')) {
+          return (
+            <h3 key={i} className="mt-6 font-display text-lg tracking-wider2 text-ink">
+              {trimmed.slice(4)}
+            </h3>
+          );
+        }
+        if (trimmed.startsWith('## ')) {
+          return (
+            <h2 key={i} className="mt-8 font-display text-xl tracking-wider2 text-gold">
+              {trimmed.slice(3)}
+            </h2>
+          );
+        }
+        if (trimmed.startsWith('# ')) {
+          return (
+            <h1 key={i} className="font-display text-3xl tracking-wider2 text-gold sm:text-4xl">
+              {trimmed.slice(2)}
+            </h1>
+          );
+        }
+        const lines = trimmed.split('\n');
+        if (lines.every((l) => /^[-*] /.test(l))) {
+          return (
+            <ul key={i} className="ml-5 list-disc space-y-1">
+              {lines.map((l, j) => (
+                <li key={j}>{renderInline(l.replace(/^[-*] /, ''))}</li>
+              ))}
+            </ul>
+          );
+        }
+        if (lines.every((l) => /^\d+\. /.test(l))) {
+          return (
+            <ol key={i} className="ml-5 list-decimal space-y-1">
+              {lines.map((l, j) => (
+                <li key={j}>{renderInline(l.replace(/^\d+\.\s/, ''))}</li>
+              ))}
+            </ol>
+          );
+        }
+        return <p key={i}>{renderInline(trimmed)}</p>;
+      })}
+    </article>
+  );
+}

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -23,7 +23,7 @@ export function ProtectedRoute({ children, role }) {
   if (!user) return <Navigate to="/login" replace state={{ from: location.pathname }} />;
 
   if (role && profile && profile.role !== role) {
-    return <Navigate to={profile.role === 'coach' ? '/coach' : '/dashboard'} replace />;
+    return <Navigate to={profile.role === 'coach' ? '/coach' : '/home'} replace />;
   }
 
   return children;

--- a/src/components/ProtectedRoute.jsx
+++ b/src/components/ProtectedRoute.jsx
@@ -3,7 +3,7 @@ import { useAuth } from '../context/AuthContext';
 import { Spinner } from './ui/Empty';
 
 export function ProtectedRoute({ children, role }) {
-  const { user, profile, loading, isSupabaseConfigured } = useAuth();
+  const { user, profile, role: effectiveRole, loading, isSupabaseConfigured } = useAuth();
   const location = useLocation();
 
   if (!isSupabaseConfigured) {
@@ -21,6 +21,9 @@ export function ProtectedRoute({ children, role }) {
 
   if (loading) return <div className="p-10"><Spinner /></div>;
   if (!user) return <Navigate to="/login" replace state={{ from: location.pathname }} />;
+
+  // Owner bypasses role gates entirely — sees client + coach surfaces.
+  if (effectiveRole === 'owner') return children;
 
   if (role && profile && profile.role !== role) {
     return <Navigate to={profile.role === 'coach' ? '/coach' : '/home'} replace />;

--- a/src/components/RequiresActiveSubscription.jsx
+++ b/src/components/RequiresActiveSubscription.jsx
@@ -1,8 +1,14 @@
-import { Navigate, useLocation } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
 import { useAuth } from '../context/AuthContext';
 import { Spinner } from './ui/Empty';
 
-const PAID_PLANS = new Set(['performance', 'identity', 'full', 'premium']);
+const PAID_PLANS = new Set([
+  'tier1', 'tier2', 'tier3',
+  // Legacy plan names kept here so subscriptions that haven't yet renewed
+  // still resolve as active. The webhook + migration roll new payments to
+  // tier1/2/3, so this list will shrink to a single set over time.
+  'performance', 'identity', 'full', 'premium',
+]);
 
 const ALLOW_WITHOUT_SUBSCRIPTION = new Set([
   '/billing',
@@ -31,8 +37,13 @@ export function RequiresActiveSubscription({ children }) {
     );
   }
 
-  if (ALLOW_WITHOUT_SUBSCRIPTION.has(location.pathname)) return children;
-  if (isActiveSubscriber(profile)) return children;
+  // When used as a layout route (no explicit children), render the matched
+  // child route via <Outlet />. When given children, render those — preserves
+  // the existing call-site that wraps <Layout />.
+  const content = children ?? <Outlet />;
+
+  if (ALLOW_WITHOUT_SUBSCRIPTION.has(location.pathname)) return content;
+  if (isActiveSubscriber(profile)) return content;
 
   return <Navigate to="/billing" replace state={{ from: location.pathname, reason: 'subscription' }} />;
 }

--- a/src/components/RequiresActiveSubscription.jsx
+++ b/src/components/RequiresActiveSubscription.jsx
@@ -17,7 +17,8 @@ const ALLOW_WITHOUT_SUBSCRIPTION = new Set([
   '/inbox',
 ]);
 
-export function isActiveSubscriber(profile) {
+export function isActiveSubscriber(profile, role) {
+  if (role === 'owner') return true;
   if (!profile) return false;
   if (profile.role === 'coach') return true;
   if (PAID_PLANS.has(profile.plan)) return true;
@@ -26,7 +27,7 @@ export function isActiveSubscriber(profile) {
 }
 
 export function RequiresActiveSubscription({ children }) {
-  const { profile, loading } = useAuth();
+  const { profile, role, loading } = useAuth();
   const location = useLocation();
 
   if (loading || !profile) {
@@ -43,7 +44,7 @@ export function RequiresActiveSubscription({ children }) {
   const content = children ?? <Outlet />;
 
   if (ALLOW_WITHOUT_SUBSCRIPTION.has(location.pathname)) return content;
-  if (isActiveSubscriber(profile)) return content;
+  if (isActiveSubscriber(profile, role)) return content;
 
   return <Navigate to="/billing" replace state={{ from: location.pathname, reason: 'subscription' }} />;
 }

--- a/src/components/SnapMealModal.jsx
+++ b/src/components/SnapMealModal.jsx
@@ -1,0 +1,186 @@
+import { useRef, useState } from 'react';
+import { Camera, X } from 'lucide-react';
+import { gemini } from '../lib/claudeClient';
+import { Button } from './ui/Button';
+
+// Snap-a-meal: user picks (or shoots) a photo, Gemini estimates items +
+// macros, user reviews + commits. The actual meals row insert happens in
+// the parent on confirm — this component is presentational + Gemini glue.
+
+async function fileToBase64(file) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => resolve(String(reader.result));
+    reader.readAsDataURL(file);
+  });
+}
+
+export function SnapMealModal({ open, onClose, onConfirm }) {
+  const fileRef = useRef(null);
+  const [previewUrl, setPreviewUrl] = useState(null);
+  const [busy, setBusy] = useState(false);
+  const [estimate, setEstimate] = useState(null);
+  const [err, setErr] = useState(null);
+  const [mealType, setMealType] = useState('meal');
+
+  function reset() {
+    setPreviewUrl(null);
+    setEstimate(null);
+    setErr(null);
+    setBusy(false);
+    setMealType('meal');
+    if (fileRef.current) fileRef.current.value = '';
+  }
+
+  function close() {
+    reset();
+    onClose?.();
+  }
+
+  async function onPick(e) {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    setErr(null);
+    setEstimate(null);
+    const dataUrl = await fileToBase64(file);
+    setPreviewUrl(dataUrl);
+    setBusy(true);
+    try {
+      const res = await gemini.mealPhoto({ image: dataUrl, mimeType: file.type || 'image/jpeg' });
+      setEstimate(res);
+    } catch (ex) {
+      setErr(ex.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function commit() {
+    if (!estimate?.items) return;
+    onConfirm?.({
+      meal_type: mealType,
+      items: estimate.items.map((it) => ({ name: it.name, qty: `${it.grams}g` })),
+      macros: estimate.total ?? {
+        kcal: estimate.items.reduce((s, it) => s + (it.kcal || 0), 0),
+        p: estimate.items.reduce((s, it) => s + (it.p || 0), 0),
+        c: estimate.items.reduce((s, it) => s + (it.c || 0), 0),
+        f: estimate.items.reduce((s, it) => s + (it.f || 0), 0),
+      },
+      source: 'gemini-photo',
+    });
+    close();
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      className="fixed inset-0 z-40 flex items-end justify-center bg-black/70 sm:items-center"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Snap a meal"
+      onClick={close}
+    >
+      <div
+        className="w-full max-w-md border-t border-line bg-bg p-5 sm:rounded-none sm:border"
+        onClick={(e) => e.stopPropagation()}
+      >
+        <div className="mb-3 flex items-center justify-between">
+          <div className="label">Snap a meal</div>
+          <button
+            type="button"
+            onClick={close}
+            aria-label="Close"
+            className="p-2 text-mute hover:text-gold"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {!previewUrl ? (
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            className="flex w-full flex-col items-center gap-3 border border-dashed border-line bg-black/20 p-8 text-mute hover:border-gold hover:text-gold"
+          >
+            <Camera size={28} />
+            <span className="text-xs uppercase tracking-widest2">Take a photo or pick one</span>
+          </button>
+        ) : (
+          <img src={previewUrl} alt="Meal" className="mb-3 max-h-64 w-full object-cover" />
+        )}
+        <input
+          ref={fileRef}
+          type="file"
+          accept="image/jpeg,image/png,image/webp,image/heic,image/heif"
+          capture="environment"
+          onChange={onPick}
+          className="hidden"
+        />
+
+        {busy ? (
+          <div className="mt-3 text-xs uppercase tracking-widest2 text-faint">Estimating macros</div>
+        ) : null}
+
+        {err ? (
+          <div className="mt-3 text-xs uppercase tracking-widest2 text-signal">{err}</div>
+        ) : null}
+
+        {estimate?.items ? (
+          <div className="mt-4 space-y-3">
+            <div className="flex items-center gap-2">
+              <label htmlFor="meal-type" className="text-[0.6rem] uppercase tracking-widest2 text-faint">
+                Type
+              </label>
+              <select
+                id="meal-type"
+                value={mealType}
+                onChange={(e) => setMealType(e.target.value)}
+                className="border border-line bg-black/40 px-2 py-1 text-xs uppercase tracking-widest2 text-ink focus:border-gold"
+              >
+                <option value="breakfast">Breakfast</option>
+                <option value="lunch">Lunch</option>
+                <option value="dinner">Dinner</option>
+                <option value="snack">Snack</option>
+                <option value="meal">Meal</option>
+              </select>
+            </div>
+            <ul className="divide-y divide-line border border-line">
+              {estimate.items.map((it, i) => (
+                <li key={i} className="flex items-baseline justify-between gap-3 px-3 py-2 text-sm">
+                  <span className="text-ink">{it.name}</span>
+                  <span className="text-xs text-faint">
+                    {it.grams}g · {it.kcal} kcal · P{it.p} C{it.c} F{it.f}
+                  </span>
+                </li>
+              ))}
+            </ul>
+            {estimate.total ? (
+              <div className="border border-line bg-black/30 px-3 py-2 text-xs text-mute">
+                <span className="text-ink">Total</span> · {estimate.total.kcal} kcal · P
+                {estimate.total.p} C{estimate.total.c} F{estimate.total.f}
+                {typeof estimate.confidence === 'number' ? (
+                  <span className="ml-2 text-faint">
+                    confidence {Math.round(estimate.confidence * 100)}%
+                  </span>
+                ) : null}
+              </div>
+            ) : null}
+            {estimate.notes ? (
+              <div className="text-[0.65rem] uppercase tracking-widest2 text-faint">
+                {estimate.notes}
+              </div>
+            ) : null}
+            <div className="flex gap-2">
+              <Button onClick={commit}>Log this meal</Button>
+              <Button variant="ghost" onClick={() => fileRef.current?.click()}>
+                Re-shoot
+              </Button>
+            </div>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/components/calendar/DayAgenda.jsx
+++ b/src/components/calendar/DayAgenda.jsx
@@ -1,0 +1,57 @@
+import { ymd } from '../../lib/dateUtils';
+import { EventChip } from './EventChip';
+
+const SECTION_ORDER = ['workout', 'meal', 'habit', 'check_in', 'program'];
+const SECTION_LABEL = {
+  workout: 'Training',
+  meal: 'Nutrition',
+  habit: 'Habits',
+  check_in: 'Check-in',
+  program: 'Program',
+};
+
+export function DayAgenda({ cursor, eventsByDay, onDropOnDay }) {
+  const events = eventsByDay[ymd(cursor)] ?? [];
+  const sections = {};
+  for (const ev of events) (sections[ev.type] ??= []).push(ev);
+
+  function allowDrop(e) {
+    if (e.dataTransfer.types.includes('application/x-pkfit-event')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+    }
+  }
+
+  function handleDrop(e) {
+    const raw = e.dataTransfer.getData('application/x-pkfit-event');
+    if (!raw) return;
+    e.preventDefault();
+    try {
+      onDropOnDay?.(JSON.parse(raw), cursor);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <div onDragOver={allowDrop} onDrop={handleDrop} className="space-y-5 border border-line bg-black/20 p-5">
+      {events.length === 0 ? (
+        <div className="text-sm text-faint">Nothing logged for this day. Drag a session in to plan it.</div>
+      ) : (
+        SECTION_ORDER.filter((k) => sections[k]?.length).map((k) => (
+          <section key={k}>
+            <div className="label mb-2">{SECTION_LABEL[k]}</div>
+            <ul className="flex flex-col gap-1">
+              {sections[k].map((ev, i) => (
+                <li key={`${ev.id}-${i}`} className="flex items-baseline gap-3">
+                  <EventChip event={ev} draggable={ev.draggable} />
+                  {ev.detail ? <span className="text-xs text-mute">{ev.detail}</span> : null}
+                </li>
+              ))}
+            </ul>
+          </section>
+        ))
+      )}
+    </div>
+  );
+}

--- a/src/components/calendar/EventChip.jsx
+++ b/src/components/calendar/EventChip.jsx
@@ -1,0 +1,47 @@
+// Color-coded event chip used in all three calendar views.
+// type → color (matches the Quiet Assassin palette)
+//   workout    : gold  (planned or completed)
+//   meal       : ink   (eaten or planned)
+//   habit      : success (a habit checked off that day)
+//   check_in   : signal (weekly check-in)
+//   program    : faint  (running program rule, not a single event)
+
+const TONE = {
+  workout: 'border-gold/60 bg-gold/15 text-gold',
+  meal: 'border-line bg-black/40 text-ink',
+  habit: 'border-success/60 bg-success/15 text-success',
+  check_in: 'border-signal/60 bg-signal/15 text-signal',
+  program: 'border-line text-faint',
+};
+
+export function EventChip({
+  event,
+  compact = false,
+  draggable = false,
+  onDragStart,
+  onDragEnd,
+}) {
+  const tone = TONE[event.type] ?? TONE.program;
+  const baseLabel = event.label ?? event.type;
+  const label = compact ? baseLabel.slice(0, 14) : baseLabel;
+  return (
+    <div
+      role="listitem"
+      draggable={draggable || undefined}
+      onDragStart={(e) => {
+        if (!draggable) return;
+        e.dataTransfer.setData('application/x-pkfit-event', JSON.stringify(event));
+        e.dataTransfer.effectAllowed = 'move';
+        onDragStart?.(event);
+      }}
+      onDragEnd={() => onDragEnd?.(event)}
+      title={event.title ?? baseLabel}
+      className={`flex items-center gap-1 truncate border ${tone} px-1.5 py-0.5 text-[0.6rem] uppercase tracking-widest2 ${
+        draggable ? 'cursor-grab active:cursor-grabbing' : ''
+      }`}
+    >
+      {event.time ? <span className="opacity-70">{event.time}</span> : null}
+      <span className="truncate">{label}</span>
+    </div>
+  );
+}

--- a/src/components/calendar/MonthGrid.jsx
+++ b/src/components/calendar/MonthGrid.jsx
@@ -1,0 +1,74 @@
+import { addDays, isSameDay, isSameMonth, monthGrid, ymd } from '../../lib/dateUtils';
+import { EventChip } from './EventChip';
+
+const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const TODAY = new Date();
+
+export function MonthGrid({ cursor, eventsByDay, onSelectDay, onDropOnDay }) {
+  const cells = monthGrid(cursor);
+
+  function allowDrop(e) {
+    if (e.dataTransfer.types.includes('application/x-pkfit-event')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+    }
+  }
+
+  function handleDrop(e, day) {
+    const raw = e.dataTransfer.getData('application/x-pkfit-event');
+    if (!raw) return;
+    e.preventDefault();
+    try {
+      onDropOnDay?.(JSON.parse(raw), day);
+    } catch {
+      /* swallow malformed payloads */
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-7 gap-px bg-line text-ink">
+      {WEEKDAY_LABELS.map((d) => (
+        <div
+          key={d}
+          className="bg-bg py-2 text-center text-[0.6rem] uppercase tracking-widest2 text-faint"
+        >
+          {d}
+        </div>
+      ))}
+      {cells.map((day) => {
+        const inMonth = isSameMonth(day, cursor);
+        const isToday = isSameDay(day, TODAY);
+        const events = eventsByDay[ymd(day)] ?? [];
+        const visible = events.slice(0, 3);
+        const overflow = events.length - visible.length;
+        return (
+          <button
+            key={day.toISOString()}
+            type="button"
+            onClick={() => onSelectDay?.(day)}
+            onDragOver={allowDrop}
+            onDrop={(e) => handleDrop(e, day)}
+            className={`flex min-h-[88px] flex-col gap-1 bg-bg p-1.5 text-left transition-colors hover:bg-black/40 ${
+              inMonth ? '' : 'text-faint opacity-50'
+            } ${isToday ? 'ring-1 ring-inset ring-gold' : ''}`}
+            aria-label={`${day.toDateString()} (${events.length} events)`}
+          >
+            <span className="self-start text-[0.7rem] tabular-nums">
+              {day.getDate()}
+            </span>
+            <div className="flex flex-col gap-0.5">
+              {visible.map((ev, i) => (
+                <EventChip key={`${ev.type}-${ev.id}-${i}`} event={ev} compact draggable={ev.draggable} />
+              ))}
+              {overflow > 0 ? (
+                <span className="text-[0.55rem] uppercase tracking-widest2 text-faint">
+                  +{overflow} more
+                </span>
+              ) : null}
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/calendar/WeekStrip.jsx
+++ b/src/components/calendar/WeekStrip.jsx
@@ -1,0 +1,67 @@
+import { isSameDay, weekDates, ymd } from '../../lib/dateUtils';
+import { EventChip } from './EventChip';
+
+const WEEKDAY_LABELS = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+const TODAY = new Date();
+
+export function WeekStrip({ cursor, eventsByDay, onSelectDay, onDropOnDay }) {
+  const days = weekDates(cursor);
+
+  function allowDrop(e) {
+    if (e.dataTransfer.types.includes('application/x-pkfit-event')) {
+      e.preventDefault();
+      e.dataTransfer.dropEffect = 'move';
+    }
+  }
+
+  function handleDrop(e, day) {
+    const raw = e.dataTransfer.getData('application/x-pkfit-event');
+    if (!raw) return;
+    e.preventDefault();
+    try {
+      onDropOnDay?.(JSON.parse(raw), day);
+    } catch {
+      /* ignore */
+    }
+  }
+
+  return (
+    <div className="grid grid-cols-7 gap-px bg-line">
+      {days.map((day, i) => {
+        const events = eventsByDay[ymd(day)] ?? [];
+        const isToday = isSameDay(day, TODAY);
+        return (
+          <div
+            key={day.toISOString()}
+            onDragOver={allowDrop}
+            onDrop={(e) => handleDrop(e, day)}
+            className={`flex min-h-[260px] flex-col gap-2 bg-bg p-2 ${
+              isToday ? 'ring-1 ring-inset ring-gold' : ''
+            }`}
+          >
+            <button
+              type="button"
+              onClick={() => onSelectDay?.(day)}
+              className="text-left"
+            >
+              <div className="text-[0.6rem] uppercase tracking-widest2 text-faint">
+                {WEEKDAY_LABELS[i]}
+              </div>
+              <div className="mt-0.5 font-display text-2xl tracking-wider2 text-gold">
+                {day.getDate()}
+              </div>
+            </button>
+            <div className="flex flex-1 flex-col gap-1 overflow-hidden">
+              {events.map((ev, idx) => (
+                <EventChip key={`${ev.type}-${ev.id}-${idx}`} event={ev} draggable={ev.draggable} />
+              ))}
+              {events.length === 0 ? (
+                <span className="text-[0.6rem] uppercase tracking-widest2 text-faint">—</span>
+              ) : null}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/src/components/ui/AppIcon.jsx
+++ b/src/components/ui/AppIcon.jsx
@@ -1,0 +1,52 @@
+import { motion } from 'framer-motion';
+import { Link } from 'react-router-dom';
+
+// iOS-style app icon: squircle (rounded-2xl approximation), gold border on
+// focus, springy press animation, optional notification badge.
+//
+// Props:
+//   to       — react-router path (renders as <Link>)
+//   label    — caption rendered below the squircle
+//   icon     — lucide-react icon component (rendered at size 28)
+//   badge    — number; rendered top-right in gold pill if > 0
+//   tone     — 'default' (gold-on-black) | 'inverse' (black-on-gold for dock)
+
+export function AppIcon({ to, label, icon: Icon, badge = 0, tone = 'default' }) {
+  const inner =
+    tone === 'inverse'
+      ? 'bg-gold text-bg'
+      : 'bg-gradient-to-br from-[#1a1a1a] to-[#0a0a0a] text-gold';
+
+  return (
+    <motion.div
+      whileTap={{ scale: 0.92 }}
+      transition={{ type: 'spring', stiffness: 500, damping: 25 }}
+      className="flex flex-col items-center"
+    >
+      <Link
+        to={to}
+        aria-label={label}
+        className="group relative block focus-visible:outline-none"
+      >
+        <div
+          className={`relative h-16 w-16 rounded-[22%] ${inner} shadow-[0_8px_24px_rgba(0,0,0,0.45)] ring-1 ring-line transition-shadow duration-200 group-focus-visible:ring-2 group-focus-visible:ring-gold sm:h-[72px] sm:w-[72px]`}
+        >
+          <div className="absolute inset-0 flex items-center justify-center">
+            <Icon size={30} strokeWidth={1.6} />
+          </div>
+          {badge > 0 ? (
+            <span
+              aria-label={`${badge} unread`}
+              className="absolute -right-1 -top-1 inline-flex min-w-[20px] items-center justify-center rounded-full bg-signal px-1.5 py-0.5 text-[0.6rem] font-semibold text-ink"
+            >
+              {badge > 99 ? '99+' : badge}
+            </span>
+          ) : null}
+        </div>
+      </Link>
+      <span className="mt-2 max-w-[80px] truncate text-center text-[0.7rem] uppercase tracking-widest2 text-mute">
+        {label}
+      </span>
+    </motion.div>
+  );
+}

--- a/src/content/legal/coaching.md
+++ b/src/content/legal/coaching.md
@@ -1,0 +1,53 @@
+# Coaching Agreement
+
+Version 1 — effective on signup.
+
+## 1. Scope
+
+PKFIT provides coaching services in the areas of training, nutrition,
+habits, recovery, and behavioral consistency. Coaching may be delivered by
+human coaches and by AI assistants operating under the same brand voice.
+
+## 2. Not a medical provider
+
+Coaches and AI assistants are not licensed medical, mental health, legal,
+or financial professionals. Recommendations are educational and reflect
+common practice in fitness coaching. They are not a substitute for advice
+from a licensed clinician.
+
+## 3. Pre-existing conditions
+
+You agree to disclose pre-existing medical conditions, medications, recent
+surgeries, pregnancy, and any acute injury that may affect training. You
+further agree to obtain clearance from a clinician before starting any new
+training regimen if there is any reason to believe such clearance is
+warranted.
+
+## 4. Assumption of risk
+
+Strength training, cardiovascular work, and dietary changes carry inherent
+risk. By using PKFIT you assume the risk of soreness, fatigue, injury,
+illness, or other adverse outcomes. You agree to train within your
+capacity and to stop or seek medical attention if symptoms emerge that
+warrant it.
+
+## 5. Honest reporting
+
+You agree to log sessions, meals, and check-ins honestly. The system's
+adjustments depend on accurate signal.
+
+## 6. Confidentiality
+
+Your data is treated as confidential. The coach (or owner) may access it
+to deliver service. Aggregated, anonymized data may be used to improve the
+product.
+
+## 7. Termination
+
+Either party may terminate the coaching relationship at any time. Outstanding
+fees through the current billing period remain due.
+
+## 8. Acknowledgment
+
+By checking this box you confirm that you have read this agreement, have
+had the opportunity to ask questions, and accept its terms.

--- a/src/content/legal/privacy.md
+++ b/src/content/legal/privacy.md
@@ -1,0 +1,71 @@
+# Privacy Policy
+
+Version 1 — effective on signup.
+
+## 1. What we collect
+
+- **Account data**: name, email, password hash (handled by Supabase Auth).
+- **Profile intake**: address, date of birth, sex, height, weight,
+  occupation, training background, goals.
+- **Medical data**: conditions, medications, allergies, injuries, emergency
+  contact. Stored AES-256-GCM encrypted at rest. The decryption key lives
+  in a separate environment and is never written to the database.
+- **Activity data**: workout sessions, meal logs, habit checks, weekly
+  check-ins, photos, conversations with the AI assistant.
+- **Billing data**: handled by Stripe. We retain Stripe customer and
+  subscription IDs only. Card numbers never reach our servers.
+
+## 2. How we use it
+
+To deliver coaching, generate AI outputs personalized to your goals, send
+operational email, process payment, and improve the product.
+
+## 3. Who can see it
+
+- You.
+- The PKFIT coach / owner (operating the service).
+- Service providers who must process the data to deliver the product:
+  Supabase (storage, auth), Anthropic (Claude AI), Google (Gemini AI),
+  fal.ai (image and video generation), Stripe (billing), Netlify
+  (hosting), and email senders. Each is bound by their own terms.
+- Law enforcement, when compelled by valid legal process.
+
+## 4. AI processing
+
+When you interact with the AI assistant or generators, your prompts and
+the relevant context (training history, intake, goals) are sent to the AI
+provider for inference. We do not allow providers to train on your data
+when an opt-out is available.
+
+## 5. Storage and retention
+
+Data is stored in Supabase, which uses AWS region us-east-1 by default.
+You can export your data at any time from Settings, or delete your
+account, which removes profile rows and orphans Stripe records to a
+canceled state.
+
+## 6. Security
+
+TLS in transit, AES-256-GCM for medical fields at rest, role-based
+row-level security on every table. We do not represent that this
+constitutes HIPAA compliance. See the Coaching Agreement: PKFIT does not
+provide medical care.
+
+## 7. Children
+
+Service is for users 18 and older. We do not knowingly collect data from
+children.
+
+## 8. Your rights
+
+You may request access, correction, export, or deletion of your data by
+emailing privacy@pkfit.app or using the in-app controls under Settings.
+
+## 9. Updates
+
+Material changes to this policy will be announced in the app and require a
+new consent acknowledgment.
+
+## 10. Contact
+
+privacy@pkfit.app

--- a/src/content/legal/terms.md
+++ b/src/content/legal/terms.md
@@ -1,0 +1,65 @@
+# Terms of Service
+
+Version 1 — effective on signup.
+
+## 1. The service
+
+PKFIT is a coaching software product. It generates training programs, meal
+scaffolds, habit prompts, and weekly review summaries with the help of
+artificial intelligence models. The output is informational. It is not
+medical, legal, or financial advice.
+
+## 2. Eligibility
+
+You must be at least 18 years old, legally capable of forming a binding
+contract, and not barred from receiving services under applicable law.
+
+## 3. Account and access
+
+You are responsible for the security of your account credentials. You agree
+to provide accurate information and to keep it current. PKFIT may suspend
+or terminate access for violations of these terms or for non-payment.
+
+## 4. Acceptable use
+
+You agree not to: misuse the service, attempt to access another user's
+account or data, reverse engineer or scrape the application, or use it to
+distribute unlawful content.
+
+## 5. Subscriptions and billing
+
+Subscriptions renew automatically at the cadence selected at checkout
+(monthly or annual). You may cancel at any time via the billing portal.
+Refunds are at PKFIT's discretion.
+
+## 6. AI-generated content
+
+AI output is generated probabilistically. It can be wrong, incomplete, or
+misaligned with your actual situation. You are responsible for evaluating
+its fitness for your purpose before acting on it.
+
+## 7. No medical relationship
+
+Use of PKFIT does not establish a doctor-patient or therapist-client
+relationship. Consult a licensed clinician for medical decisions.
+
+## 8. Limitation of liability
+
+To the maximum extent allowed by law, PKFIT and its operators are not
+liable for indirect, incidental, special, or consequential damages, or for
+amounts in excess of fees paid by you in the prior twelve months.
+
+## 9. Changes
+
+We may revise these terms. Material changes will be announced in the app
+and acknowledged via a renewed consent prompt.
+
+## 10. Governing law
+
+These terms are governed by the laws of the State of Texas, United States,
+without regard to conflict of laws principles. Disputes will be resolved
+in the state or federal courts located in Travis County, Texas.
+
+## 11. Contact
+
+For questions or notices: legal@pkfit.app.

--- a/src/context/AuthContext.jsx
+++ b/src/context/AuthContext.jsx
@@ -3,6 +3,20 @@ import { supabase, isSupabaseConfigured } from '../lib/supabaseClient';
 
 const AuthContext = createContext(null);
 
+// Client-side owner hint used only for UI visibility (showing the /owner
+// tile, theming, etc.). Server-side `OWNER_EMAILS` is the source of truth
+// for any privileged action — bypassing the client check just shows an
+// extra link that the server still rejects.
+const OWNER_EMAILS = (import.meta.env.VITE_OWNER_EMAILS ?? '')
+  .split(',')
+  .map((s) => s.trim().toLowerCase())
+  .filter(Boolean);
+
+function isOwnerEmail(email) {
+  if (!email) return false;
+  return OWNER_EMAILS.includes(String(email).trim().toLowerCase());
+}
+
 export function AuthProvider({ children }) {
   const [session, setSession] = useState(null);
   const [profile, setProfile] = useState(null);
@@ -71,7 +85,9 @@ export function AuthProvider({ children }) {
 
   const value = useMemo(() => {
     const user = session?.user ?? null;
-    const role = profile?.role ?? null;
+    const baseRole = profile?.role ?? null;
+    const role = isOwnerEmail(user?.email) ? 'owner' : baseRole;
+    const isOwner = role === 'owner';
 
     async function signIn(email, password) {
       if (!isSupabaseConfigured) throw new Error('Supabase not configured');
@@ -98,6 +114,7 @@ export function AuthProvider({ children }) {
       user,
       profile,
       role,
+      isOwner,
       loading,
       signIn,
       signUp,

--- a/src/lib/claudeClient.js
+++ b/src/lib/claudeClient.js
@@ -129,3 +129,13 @@ export const account = {
 export const coach = {
   exportClient: (clientId) => callFunction('coach-export-client', { clientId }),
 };
+
+export const profileApi = {
+  // Update intake / medical / consent / name. Medical is encrypted at rest.
+  update: (input) => callFunction('update-profile', input),
+  getMedical: () => callFunction('get-my-medical', {}),
+};
+
+export const apify = {
+  importTrainerize: (sourceUrl) => callFunction('apify-import', { sourceUrl }),
+};

--- a/src/lib/claudeClient.js
+++ b/src/lib/claudeClient.js
@@ -38,6 +38,26 @@ export const claude = {
   weeklyReview: (input) => callFunction('generate-weekly-review', input),
 };
 
+// Strip the data: URL prefix Gemini doesn't want when sending inline data.
+function stripDataUrl(maybeDataUrl) {
+  if (typeof maybeDataUrl !== 'string') return maybeDataUrl;
+  const m = maybeDataUrl.match(/^data:([^;]+);base64,(.*)$/);
+  if (!m) return maybeDataUrl;
+  return m[2];
+}
+
+export const gemini = {
+  // image: base64 (with or without data: prefix); mimeType: image/jpeg etc.
+  mealPhoto: ({ image, mimeType }) =>
+    callFunction('gemini-meal-photo', { image: stripDataUrl(image), mimeType }),
+  // audio: base64; mimeType: audio/webm etc.
+  voiceTurn: ({ audio, mimeType }) =>
+    callFunction('gemini-voice-turn', { audio: stripDataUrl(audio), mimeType }),
+  // video: base64; mimeType: video/mp4 etc.; exercise: optional string label.
+  formCheck: ({ video, mimeType, exercise }) =>
+    callFunction('gemini-form-check', { video: stripDataUrl(video), mimeType, exercise }),
+};
+
 // Parse a text/event-stream body into { event, data } frames.
 function parseSseFrame(raw) {
   const lines = raw.split(/\r?\n/);

--- a/src/lib/claudeClient.js
+++ b/src/lib/claudeClient.js
@@ -139,3 +139,8 @@ export const profileApi = {
 export const apify = {
   importTrainerize: (sourceUrl) => callFunction('apify-import', { sourceUrl }),
 };
+
+export const images = {
+  generate: ({ prompt, model, aspect_ratio, num_images, style_prompt }) =>
+    callFunction('generate-image', { prompt, model, aspect_ratio, num_images, style_prompt }),
+};

--- a/src/lib/dateUtils.js
+++ b/src/lib/dateUtils.js
@@ -1,0 +1,72 @@
+// Calendar date math. Local time throughout — the user's wall clock is what
+// matters for what "Tuesday" means, not UTC.
+
+export function ymd(date) {
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}
+
+export function startOfDay(date) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function addDays(date, n) {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + n);
+}
+
+export function startOfWeek(date, weekStartsOn = 0) {
+  const d = startOfDay(date);
+  const diff = (d.getDay() - weekStartsOn + 7) % 7;
+  return addDays(d, -diff);
+}
+
+export function startOfMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth(), 1);
+}
+
+export function endOfMonth(date) {
+  return new Date(date.getFullYear(), date.getMonth() + 1, 0);
+}
+
+// Six-week grid (42 cells) covering the month containing `date`. Apple's
+// month view always shows trailing/leading days from adjacent months so the
+// grid is rectangular and dates never reflow when the user pages.
+export function monthGrid(date, weekStartsOn = 0) {
+  const first = startOfMonth(date);
+  const gridStart = startOfWeek(first, weekStartsOn);
+  return Array.from({ length: 42 }, (_, i) => addDays(gridStart, i));
+}
+
+export function weekDates(date, weekStartsOn = 0) {
+  const start = startOfWeek(date, weekStartsOn);
+  return Array.from({ length: 7 }, (_, i) => addDays(start, i));
+}
+
+export function isSameDay(a, b) {
+  return (
+    a.getFullYear() === b.getFullYear() &&
+    a.getMonth() === b.getMonth() &&
+    a.getDate() === b.getDate()
+  );
+}
+
+export function isSameMonth(a, b) {
+  return a.getFullYear() === b.getFullYear() && a.getMonth() === b.getMonth();
+}
+
+export function formatRange(view, cursor) {
+  if (view === 'month') {
+    return cursor.toLocaleString(undefined, { month: 'long', year: 'numeric' });
+  }
+  if (view === 'week') {
+    const start = startOfWeek(cursor);
+    const end = addDays(start, 6);
+    const sameMonth = start.getMonth() === end.getMonth();
+    const startStr = start.toLocaleString(undefined, sameMonth ? { month: 'long', day: 'numeric' } : { month: 'short', day: 'numeric' });
+    const endStr = end.toLocaleString(undefined, sameMonth ? { day: 'numeric', year: 'numeric' } : { month: 'short', day: 'numeric', year: 'numeric' });
+    return `${startStr} – ${endStr}`;
+  }
+  return cursor.toLocaleString(undefined, { weekday: 'long', month: 'long', day: 'numeric', year: 'numeric' });
+}

--- a/src/lib/legalVersions.js
+++ b/src/lib/legalVersions.js
@@ -1,0 +1,19 @@
+// Bumped when the corresponding /content/legal/*.md file changes materially.
+// Stored on profiles.consent so the app can detect a stale acceptance and
+// re-prompt the user. Kept here (not in env) so a deploy is the unit of
+// change, not a config tweak.
+
+export const TOS_V = 1;
+export const COACHING_V = 1;
+export const PRIVACY_V = 1;
+
+export const CURRENT = { tos_v: TOS_V, coaching_v: COACHING_V, privacy_v: PRIVACY_V };
+
+export function consentIsCurrent(consent) {
+  if (!consent) return false;
+  return (
+    consent.tos_v === TOS_V &&
+    consent.coaching_v === COACHING_V &&
+    consent.privacy_v === PRIVACY_V
+  );
+}

--- a/src/lib/units.js
+++ b/src/lib/units.js
@@ -83,3 +83,17 @@ export function parseHeightToCm(input, units = 'imperial') {
   if (Number.isNaN(n)) return null;
   return units === 'imperial' ? inchesToCm(n) : round1(n);
 }
+
+// Convert separate feet and inches inputs to cm. Either may be empty.
+export function feetInchesToCm(feet, inches) {
+  const f = Number(feet || 0);
+  const i = Number(inches || 0);
+  if (Number.isNaN(f) && Number.isNaN(i)) return null;
+  if (!feet && !inches) return null;
+  const totalInches = (Number.isNaN(f) ? 0 : f) * 12 + (Number.isNaN(i) ? 0 : i);
+  return round1(totalInches * 2.54);
+}
+
+export function lbsToKgRaw(lbs) {
+  return lbsToKg(lbs);
+}

--- a/src/pages/HomeScreen.jsx
+++ b/src/pages/HomeScreen.jsx
@@ -1,0 +1,161 @@
+import { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  Dumbbell,
+  UtensilsCrossed,
+  Target,
+  CalendarDays,
+  Sparkles,
+  Users,
+  CreditCard,
+  UserCircle2,
+  ClipboardCheck,
+  Inbox,
+  LayoutDashboard,
+  Settings as SettingsIcon,
+  LogOut,
+} from 'lucide-react';
+import { motion } from 'framer-motion';
+import { useAuth } from '../context/AuthContext';
+import { useUnreadDMs } from '../hooks/useUnreadDMs';
+import { useUnreadCommunity } from '../hooks/useUnreadCommunity';
+import { AppIcon } from '../components/ui/AppIcon';
+import { Avatar } from '../components/ui/Avatar';
+
+// iPhone-style home screen. Replaces the previous post-login dashboard as the
+// default landing surface. The dashboard remains accessible as the "Today"
+// tile so the existing widget content (loop stage, macro floors) is one tap
+// away. Bottom dock holds the four highest-frequency actions.
+
+const APPS = [
+  { to: '/dashboard', label: 'Today', icon: LayoutDashboard },
+  { to: '/workouts', label: 'Workouts', icon: Dumbbell },
+  { to: '/meals', label: 'Meals', icon: UtensilsCrossed },
+  { to: '/habits', label: 'Habits', icon: Target },
+  { to: '/reviews', label: 'Reviews', icon: ClipboardCheck },
+  { to: '/community', label: 'Community', icon: Users, badgeKey: 'community' },
+  { to: '/inbox', label: 'Inbox', icon: Inbox, badgeKey: 'dms' },
+  { to: '/billing', label: 'Billing', icon: CreditCard },
+  { to: '/settings', label: 'Settings', icon: SettingsIcon },
+];
+
+const DOCK = [
+  { to: '/assistant', label: 'Coach', icon: Sparkles, tone: 'inverse' },
+  { to: '/calendar', label: 'Calendar', icon: CalendarDays, tone: 'inverse' },
+  { to: '/profile', label: 'Profile', icon: UserCircle2, tone: 'inverse' },
+];
+
+function formatGreeting(date = new Date()) {
+  const h = date.getHours();
+  if (h < 5) return 'Late';
+  if (h < 12) return 'Morning';
+  if (h < 18) return 'Afternoon';
+  return 'Evening';
+}
+
+export default function HomeScreen() {
+  const { user, profile, role, signOut } = useAuth();
+  const nav = useNavigate();
+  const unreadDMs = useUnreadDMs({ userId: user?.id, role });
+  const unreadCommunity = useUnreadCommunity({
+    userId: user?.id,
+    lastSeenAt: profile?.community_last_seen_at,
+  });
+
+  const badges = { dms: unreadDMs, community: role === 'coach' ? 0 : unreadCommunity };
+
+  // Cmd/Ctrl+K shortcut to Assistant — same shortcut Layout.jsx wires.
+  useEffect(() => {
+    function onKey(e) {
+      if ((e.metaKey || e.ctrlKey) && !e.shiftKey && !e.altKey && e.key.toLowerCase() === 'k') {
+        const tag = document.activeElement?.tagName;
+        if (tag === 'INPUT' || tag === 'TEXTAREA') return;
+        e.preventDefault();
+        nav('/assistant');
+      }
+    }
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [nav]);
+
+  async function handleSignOut() {
+    await signOut();
+    nav('/', { replace: true });
+  }
+
+  const today = new Date().toLocaleDateString(undefined, {
+    weekday: 'long',
+    month: 'long',
+    day: 'numeric',
+  });
+  const greeting = formatGreeting();
+  const displayName = profile?.name?.split(' ')?.[0] ?? profile?.email?.split('@')?.[0] ?? 'Member';
+
+  return (
+    <div
+      className="relative min-h-screen overflow-hidden bg-bg text-ink"
+      style={{
+        backgroundImage:
+          'radial-gradient(1100px 700px at 75% -10%, rgba(201,168,76,0.12), transparent 60%), radial-gradient(900px 600px at 10% 110%, rgba(201,168,76,0.08), transparent 55%)',
+      }}
+    >
+      <header className="relative z-10 mx-auto flex max-w-3xl items-center justify-between px-6 pt-10 pb-4">
+        <div>
+          <div className="text-[0.6rem] uppercase tracking-widest2 text-faint">{today}</div>
+          <div className="mt-1 font-display text-3xl tracking-wider2 text-gold">
+            {greeting}, {displayName}.
+          </div>
+        </div>
+        <div className="flex items-center gap-3">
+          <Avatar name={profile?.name ?? 'Me'} path={profile?.avatar_path} size={32} />
+          <button
+            type="button"
+            onClick={handleSignOut}
+            aria-label="Sign out"
+            className="text-mute transition-colors hover:text-gold focus-visible:outline focus-visible:outline-1 focus-visible:outline-gold"
+          >
+            <LogOut size={16} />
+          </button>
+        </div>
+      </header>
+
+      <motion.main
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.45, ease: [0.2, 0.6, 0.2, 1] }}
+        className="relative z-10 mx-auto max-w-3xl px-6 pb-44 pt-4"
+      >
+        <div
+          className="grid gap-y-7 gap-x-4"
+          style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(76px, 1fr))' }}
+        >
+          {APPS.map((app) => (
+            <AppIcon
+              key={app.to}
+              to={app.to}
+              label={app.label}
+              icon={app.icon}
+              badge={app.badgeKey ? badges[app.badgeKey] ?? 0 : 0}
+            />
+          ))}
+        </div>
+      </motion.main>
+
+      <nav
+        aria-label="Primary"
+        className="fixed inset-x-0 bottom-4 z-20 mx-auto flex max-w-md items-center justify-around rounded-[28px] border border-line bg-black/60 px-5 py-3 backdrop-blur-md"
+        style={{ width: 'calc(100% - 32px)' }}
+      >
+        {DOCK.map((item) => (
+          <AppIcon
+            key={item.to}
+            to={item.to}
+            label={item.label}
+            icon={item.icon}
+            tone={item.tone}
+          />
+        ))}
+      </nav>
+    </div>
+  );
+}

--- a/src/pages/HomeScreen.jsx
+++ b/src/pages/HomeScreen.jsx
@@ -13,6 +13,7 @@ import {
   Inbox,
   LayoutDashboard,
   Settings as SettingsIcon,
+  ShieldCheck,
   LogOut,
 } from 'lucide-react';
 import { motion } from 'framer-motion';
@@ -63,6 +64,10 @@ export default function HomeScreen() {
   });
 
   const badges = { dms: unreadDMs, community: role === 'coach' ? 0 : unreadCommunity };
+  // Owner gets an extra tile that links to /owner. Hidden for everyone else.
+  const apps = role === 'owner'
+    ? [...APPS, { to: '/owner', label: 'Owner', icon: ShieldCheck }]
+    : APPS;
 
   // Cmd/Ctrl+K shortcut to Assistant — same shortcut Layout.jsx wires.
   useEffect(() => {
@@ -129,7 +134,7 @@ export default function HomeScreen() {
           className="grid gap-y-7 gap-x-4"
           style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(76px, 1fr))' }}
         >
-          {APPS.map((app) => (
+          {apps.map((app) => (
             <AppIcon
               key={app.to}
               to={app.to}

--- a/src/pages/Landing.jsx
+++ b/src/pages/Landing.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom';
+import { CinematicIntro } from '../components/CinematicIntro';
 
 const features = [
   { n: '01', title: 'Diagnosis Protocol', body: 'Baseline intake. Body composition, sleep, stress, lifts. Signal over story.' },
@@ -19,6 +20,7 @@ const phases = [
 export default function Landing() {
   return (
     <div className="min-h-screen bg-bg text-ink">
+      <CinematicIntro />
       <section className="mx-auto flex min-h-screen max-w-5xl flex-col justify-center px-5 py-24">
         <div className="label mb-4">The PKFIT Blueprint · A 30-Day System</div>
         <h1 className="font-display text-[clamp(3rem,8vw,7rem)] leading-[0.95] tracking-wider2 text-gold">

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -4,8 +4,8 @@ import { useAuth } from '../context/AuthContext';
 export default function NotFound() {
   const location = useLocation();
   const { user, role } = useAuth();
-  const homePath = !user ? '/' : role === 'coach' ? '/coach' : '/dashboard';
-  const homeLabel = !user ? 'Landing' : role === 'coach' ? 'Coach overview' : 'Dashboard';
+  const homePath = !user ? '/' : role === 'coach' ? '/coach' : '/home';
+  const homeLabel = !user ? 'Landing' : role === 'coach' ? 'Coach overview' : 'Home';
   return (
     <div className="mx-auto flex min-h-screen max-w-reading flex-col justify-center px-5 py-16">
       <div className="label mb-2">404</div>

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -165,7 +165,7 @@ export default function Onboarding() {
         /* ignore */
       }
       await refreshProfile?.();
-      navigate('/dashboard', { replace: true });
+      navigate('/home', { replace: true });
     } catch (e) {
       setErr(e.message);
     } finally {

--- a/src/pages/Onboarding.jsx
+++ b/src/pages/Onboarding.jsx
@@ -164,6 +164,17 @@ export default function Onboarding() {
       } catch {
         /* ignore */
       }
+      // If signup captured consent versions in user_metadata, persist them
+      // to profiles.consent now that we have an authenticated session.
+      const consentMeta = user?.user_metadata?.consent;
+      if (consentMeta) {
+        try {
+          const { profileApi } = await import('../lib/claudeClient');
+          await profileApi.update({ consent: consentMeta });
+        } catch {
+          // Non-fatal: user can re-accept under Settings if this fails.
+        }
+      }
       await refreshProfile?.();
       navigate('/home', { replace: true });
     } catch (e) {

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -25,10 +25,9 @@ const TILES = [
   },
   {
     label: 'Image Lab',
-    desc: 'fal.ai generation. Drops to /home dock when ready.',
+    desc: 'fal.ai Flux. Prompt, model, aspect — cost tracked per call.',
     to: '/owner/images',
     icon: ImageIcon,
-    disabled: true,
   },
   {
     label: 'Clients',

--- a/src/pages/Owner.jsx
+++ b/src/pages/Owner.jsx
@@ -1,0 +1,169 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import {
+  ArrowLeft,
+  Sparkles,
+  Image as ImageIcon,
+  Users,
+  CalendarDays,
+  Activity,
+  Database,
+} from 'lucide-react';
+import { useAuth } from '../context/AuthContext';
+
+// Owner panel — only renders when role === 'owner'. Provides a dashboard of
+// the surfaces Percy uses to dogfood + admin the system. Server-side
+// OWNER_EMAILS is what actually gates writes; this page is just navigation
+// and read-only summaries.
+
+const TILES = [
+  {
+    label: 'Personal Assistant',
+    desc: 'Unrestricted Quiet Assassin. Opus 4.7 default.',
+    to: '/assistant',
+    icon: Sparkles,
+  },
+  {
+    label: 'Image Lab',
+    desc: 'fal.ai generation. Drops to /home dock when ready.',
+    to: '/owner/images',
+    icon: ImageIcon,
+    disabled: true,
+  },
+  {
+    label: 'Clients',
+    desc: 'Read-only client roster. Inspect any session, meal, habit.',
+    to: '/coach/clients',
+    icon: Users,
+  },
+  {
+    label: 'Programs',
+    desc: 'Master program catalog used by the generator.',
+    to: '/coach/programs',
+    icon: CalendarDays,
+  },
+  {
+    label: 'Cost Log',
+    desc: 'Anthropic + fal.ai usage. Per-tier, per-day rollup.',
+    to: '/owner/costs',
+    icon: Activity,
+    disabled: true,
+  },
+  {
+    label: 'Raw Data',
+    desc: 'Read-only SQL views (profiles, payments, sessions).',
+    to: '/owner/data',
+    icon: Database,
+    disabled: true,
+  },
+];
+
+export default function Owner() {
+  const { profile, role } = useAuth();
+  const nav = useNavigate();
+  const [filter, setFilter] = useState('all');
+
+  if (role !== 'owner') {
+    return (
+      <div className="mx-auto max-w-reading p-10">
+        <div className="label mb-2">Restricted</div>
+        <h1 className="font-display text-3xl tracking-wider2 text-gold">Owner only</h1>
+        <p className="mt-3 text-sm text-mute">
+          Add your email to the <code className="text-gold">OWNER_EMAILS</code> server env var
+          (and <code className="text-gold">VITE_OWNER_EMAILS</code> for UI visibility) to access
+          this surface.
+        </p>
+      </div>
+    );
+  }
+
+  const tiles = filter === 'available' ? TILES.filter((t) => !t.disabled) : TILES;
+
+  return (
+    <div className="min-h-screen bg-bg text-ink">
+      <header className="mx-auto flex max-w-4xl items-center justify-between px-6 pt-10 pb-6">
+        <button
+          type="button"
+          onClick={() => nav('/home')}
+          className="flex items-center gap-2 text-mute transition-colors hover:text-gold"
+          aria-label="Back to home"
+        >
+          <ArrowLeft size={16} />
+          <span className="text-xs uppercase tracking-widest2">Home</span>
+        </button>
+        <div className="text-right">
+          <div className="text-[0.6rem] uppercase tracking-widest2 text-faint">Signed in</div>
+          <div className="font-display text-lg tracking-wider2 text-gold">
+            {profile?.name ?? profile?.email ?? 'Owner'}
+          </div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-4xl px-6 pb-24">
+        <div className="mb-2 label">Owner Panel</div>
+        <h1 className="font-display text-4xl tracking-wider2 text-gold sm:text-5xl">
+          Operate /axiom
+        </h1>
+        <p className="mt-3 max-w-reading text-sm text-mute">
+          Unrestricted surfaces. Top model by default. No tier gates, no rate limits, no
+          coaching-scope refusals. Server enforces OWNER_EMAILS — the UI here only renders
+          for you.
+        </p>
+
+        <div className="mt-8 inline-flex border border-line">
+          {['all', 'available'].map((v) => (
+            <button
+              key={v}
+              type="button"
+              onClick={() => setFilter(v)}
+              className={`px-4 py-2 text-xs uppercase tracking-widest2 transition-colors ${
+                filter === v ? 'bg-gold text-bg' : 'text-mute hover:text-ink'
+              }`}
+            >
+              {v}
+            </button>
+          ))}
+        </div>
+
+        <section className="mt-6 grid grid-cols-1 gap-4 sm:grid-cols-2">
+          {tiles.map((t) => {
+            const Icon = t.icon;
+            const className = `flex flex-col gap-2 border bg-black/30 p-5 text-left transition-colors ${
+              t.disabled
+                ? 'border-line/30 text-faint'
+                : 'border-line hover:border-gold hover:text-gold'
+            }`;
+            const inner = (
+              <>
+                <div className="flex items-center justify-between">
+                  <Icon size={18} />
+                  {t.disabled ? (
+                    <span className="text-[0.6rem] uppercase tracking-widest2 text-faint">
+                      Soon
+                    </span>
+                  ) : null}
+                </div>
+                <div className="font-display text-xl tracking-wider2">{t.label}</div>
+                <div className="text-sm text-mute">{t.desc}</div>
+              </>
+            );
+            return t.disabled ? (
+              <div key={t.label} className={className} aria-disabled>
+                {inner}
+              </div>
+            ) : (
+              <button
+                key={t.label}
+                type="button"
+                onClick={() => nav(t.to)}
+                className={className}
+              >
+                {inner}
+              </button>
+            );
+          })}
+        </section>
+      </main>
+    </div>
+  );
+}

--- a/src/pages/Splash.jsx
+++ b/src/pages/Splash.jsx
@@ -16,5 +16,5 @@ export default function Splash() {
   }
 
   if (!user) return <Navigate to="/" replace />;
-  return <Navigate to={profile?.role === 'coach' ? '/coach' : '/dashboard'} replace />;
+  return <Navigate to={profile?.role === 'coach' ? '/coach' : '/home'} replace />;
 }

--- a/src/pages/auth/Login.jsx
+++ b/src/pages/auth/Login.jsx
@@ -19,7 +19,7 @@ export default function Login() {
     setBusy(true);
     try {
       await signIn(email, password);
-      const dest = location.state?.from || '/dashboard';
+      const dest = location.state?.from || '/home';
       navigate(dest, { replace: true });
     } catch (e) {
       const msg = (e?.message ?? '').toLowerCase();

--- a/src/pages/auth/Signup.jsx
+++ b/src/pages/auth/Signup.jsx
@@ -3,6 +3,7 @@ import { Link, useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
 import { Button } from '../../components/ui/Button';
 import { Input } from '../../components/ui/Input';
+import { CURRENT } from '../../lib/legalVersions';
 
 export default function Signup() {
   const { signUp, isSupabaseConfigured } = useAuth();
@@ -10,16 +11,28 @@ export default function Signup() {
   const [name, setName] = useState('');
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
+  const [tos, setTos] = useState(false);
+  const [coaching, setCoaching] = useState(false);
+  const [privacy, setPrivacy] = useState(false);
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
   const [sent, setSent] = useState(false);
 
+  const consentReady = tos && coaching && privacy;
+
   async function onSubmit(e) {
     e.preventDefault();
+    if (!consentReady) {
+      setErr('Read and accept all three agreements to continue.');
+      return;
+    }
     setErr(null);
     setBusy(true);
     try {
-      await signUp(email, password, { name });
+      // Pass consent versions through user metadata. Onboarding (or
+      // /update-profile after first login) writes the row to profiles.consent
+      // with timestamp + UA — auth signup itself can't write to other tables.
+      await signUp(email, password, { name, consent: CURRENT });
       setSent(true);
     } catch (e) {
       const msg = (e?.message ?? '').toLowerCase();
@@ -72,11 +85,64 @@ export default function Signup() {
             onChange={(e) => setPassword(e.target.value)}
           />
           <p className="text-[0.65rem] uppercase tracking-widest2 text-faint">Eight characters minimum.</p>
+
+          <fieldset className="space-y-2 border border-line bg-black/30 p-3 text-xs text-mute">
+            <legend className="px-1 label">Agreements</legend>
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={tos}
+                onChange={(e) => setTos(e.target.checked)}
+                className="mt-0.5 accent-gold"
+                required
+              />
+              <span>
+                I have read and accept the{' '}
+                <Link to="/legal/terms" target="_blank" className="text-gold underline">
+                  Terms of Service
+                </Link>
+                .
+              </span>
+            </label>
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={coaching}
+                onChange={(e) => setCoaching(e.target.checked)}
+                className="mt-0.5 accent-gold"
+                required
+              />
+              <span>
+                I have read and accept the{' '}
+                <Link to="/legal/coaching" target="_blank" className="text-gold underline">
+                  Coaching Agreement
+                </Link>
+                , including the assumption of risk.
+              </span>
+            </label>
+            <label className="flex items-start gap-2">
+              <input
+                type="checkbox"
+                checked={privacy}
+                onChange={(e) => setPrivacy(e.target.checked)}
+                className="mt-0.5 accent-gold"
+                required
+              />
+              <span>
+                I have read the{' '}
+                <Link to="/legal/privacy" target="_blank" className="text-gold underline">
+                  Privacy Policy
+                </Link>{' '}
+                and consent to the processing described.
+              </span>
+            </label>
+          </fieldset>
+
           {err ? <div role="alert" className="text-xs uppercase tracking-widest2 text-signal">{err}</div> : null}
           {!isSupabaseConfigured ? (
             <div className="border border-line p-3 text-xs text-faint">Supabase environment not set. Signup is inactive.</div>
           ) : null}
-          <Button type="submit" disabled={busy || !isSupabaseConfigured} className="w-full">
+          <Button type="submit" disabled={busy || !isSupabaseConfigured || !consentReady} className="w-full">
             {busy ? 'Creating' : 'Create account'}
           </Button>
         </form>

--- a/src/pages/client/Assistant.jsx
+++ b/src/pages/client/Assistant.jsx
@@ -1,10 +1,19 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { Plus, Trash2 } from 'lucide-react';
+import { Plus, Trash2, Mic, Square } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { supabase, isSupabaseConfigured } from '../../lib/supabaseClient';
-import { streamAssistant } from '../../lib/claudeClient';
+import { streamAssistant, gemini } from '../../lib/claudeClient';
 import { Button } from '../../components/ui/Button';
 import { ContextPinMenu } from '../../components/ContextPinMenu';
+
+async function blobToBase64(blob) {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => resolve(String(reader.result));
+    reader.readAsDataURL(blob);
+  });
+}
 
 export default function Assistant() {
   const { user } = useAuth();
@@ -15,6 +24,10 @@ export default function Assistant() {
   const [input, setInput] = useState('');
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState(null);
+  const [recording, setRecording] = useState(false);
+  const [transcribing, setTranscribing] = useState(false);
+  const recorderRef = useRef(null);
+  const chunksRef = useRef([]);
   const endRef = useRef(null);
 
   const loadConversations = useCallback(async () => {
@@ -105,6 +118,51 @@ export default function Assistant() {
     } finally {
       setBusy(false);
     }
+  }
+
+  async function startRecording() {
+    setErr(null);
+    if (!navigator.mediaDevices?.getUserMedia) {
+      setErr('Microphone is not available in this browser.');
+      return;
+    }
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const mimeType = MediaRecorder.isTypeSupported('audio/webm') ? 'audio/webm' : 'audio/mp4';
+      const recorder = new MediaRecorder(stream, { mimeType });
+      chunksRef.current = [];
+      recorder.ondataavailable = (e) => {
+        if (e.data.size > 0) chunksRef.current.push(e.data);
+      };
+      recorder.onstop = async () => {
+        stream.getTracks().forEach((t) => t.stop());
+        const blob = new Blob(chunksRef.current, { type: mimeType });
+        chunksRef.current = [];
+        if (blob.size === 0) return;
+        setTranscribing(true);
+        try {
+          const dataUrl = await blobToBase64(blob);
+          const { transcript } = await gemini.voiceTurn({ audio: dataUrl, mimeType });
+          if (transcript) setInput((cur) => (cur ? `${cur} ${transcript}` : transcript));
+        } catch (ex) {
+          setErr(ex.message);
+        } finally {
+          setTranscribing(false);
+        }
+      };
+      recorder.start();
+      recorderRef.current = recorder;
+      setRecording(true);
+    } catch (ex) {
+      setErr(ex?.message ?? 'Microphone access denied');
+    }
+  }
+
+  function stopRecording() {
+    const recorder = recorderRef.current;
+    if (recorder && recorder.state === 'recording') recorder.stop();
+    recorderRef.current = null;
+    setRecording(false);
   }
 
   function startNew() {
@@ -214,10 +272,27 @@ export default function Assistant() {
           <input
             value={input}
             onChange={(e) => setInput(e.target.value)}
-            placeholder="Ask a specific question"
-            className="flex-1 border border-line bg-black/40 px-4 py-3 font-body text-ink placeholder:text-faint focus:border-gold"
+            placeholder={transcribing ? 'Transcribing…' : 'Ask a specific question'}
+            disabled={transcribing}
+            className="flex-1 border border-line bg-black/40 px-4 py-3 font-body text-ink placeholder:text-faint focus:border-gold disabled:opacity-60"
           />
-          <Button type="submit" disabled={busy || !input.trim()}>{busy ? 'Thinking' : 'Send'}</Button>
+          <button
+            type="button"
+            onClick={recording ? stopRecording : startRecording}
+            disabled={transcribing || busy}
+            aria-label={recording ? 'Stop recording' : 'Record voice'}
+            aria-pressed={recording}
+            className={`flex h-12 w-12 items-center justify-center border ${
+              recording
+                ? 'border-signal bg-signal/20 text-signal'
+                : 'border-line bg-black/40 text-mute hover:border-gold hover:text-gold'
+            } disabled:opacity-60`}
+          >
+            {recording ? <Square size={16} /> : <Mic size={16} />}
+          </button>
+          <Button type="submit" disabled={busy || !input.trim() || recording || transcribing}>
+            {busy ? 'Thinking' : 'Send'}
+          </Button>
         </form>
       </section>
     </div>

--- a/src/pages/client/Billing.jsx
+++ b/src/pages/client/Billing.jsx
@@ -8,53 +8,52 @@ import { Badge } from '../../components/ui/Badge';
 import { Card, CardHeader } from '../../components/ui/Card';
 import { Spinner } from '../../components/ui/Empty';
 
+const LEGACY_TIER_MAP = {
+  performance: 'tier1',
+  identity: 'tier1',
+  full: 'tier2',
+  premium: 'tier3',
+};
+
 const PLANS = [
   {
-    tier: 'performance',
-    label: 'Performance Standard',
+    tier: 'tier1',
+    label: 'Standard',
     monthly: 250,
+    model: 'Claude Haiku',
     headline: 'Diagnose. Program. Lock.',
     features: [
       'Programmed lifting split',
       'Macro floor + meal scaffolding',
       'Weekly written check-in',
-      'Inbox response within 48 hours',
+      'Claude Haiku coaching chat',
     ],
   },
   {
-    tier: 'identity',
-    label: 'Identity Architecture',
-    monthly: 350,
+    tier: 'tier2',
+    label: 'Integration',
+    monthly: 475,
+    model: 'Claude Sonnet',
     headline: 'Performance plus the loop work.',
     features: [
-      'Everything in Performance',
+      'Everything in Standard',
       'Habit stack design + tracking',
-      'Identity mapping session',
-      'Inbox response within 24 hours',
+      'Identity mapping + nutrition adjustments',
+      'Claude Sonnet coaching chat',
     ],
   },
   {
-    tier: 'full',
-    label: 'Full Integration',
-    monthly: 450,
-    headline: 'Training, nutrition, habits, all locked.',
-    features: [
-      'Everything in Identity',
-      'Loop reviews twice per week',
-      'Nutrition adjustments on demand',
-      'Direct DM thread with the coach',
-    ],
-  },
-  {
-    tier: 'premium',
-    label: 'Premium',
+    tier: 'tier3',
+    label: 'Architect',
     monthly: 750,
-    headline: 'Direct access. Faster cycle.',
+    model: 'Claude Opus',
+    headline: 'Direct access. Highest reasoning.',
     features: [
-      'Everything in Full Integration',
+      'Everything in Integration',
       'Same-day inbox response',
       'Quarterly in-depth review',
-      'Priority on protocol updates',
+      'Claude Opus coaching chat',
+      'Optional: bring your own Anthropic API key',
     ],
   },
 ];
@@ -65,6 +64,12 @@ function annualEffective(monthly) {
 
 function annualSavings(monthly) {
   return Math.round(monthly * 12 * 0.17);
+}
+
+function normalizeTier(plan) {
+  if (!plan || plan === 'trial') return null;
+  if (plan === 'tier1' || plan === 'tier2' || plan === 'tier3') return plan;
+  return LEGACY_TIER_MAP[plan] ?? null;
 }
 
 export default function Billing() {
@@ -95,7 +100,7 @@ export default function Billing() {
     };
   }, [user?.id]);
 
-  const currentTier = profile?.plan && profile.plan !== 'trial' ? profile.plan : null;
+  const currentTier = normalizeTier(profile?.plan);
   const isActive = payment?.status === 'active';
 
   async function checkout(tier) {
@@ -138,7 +143,7 @@ export default function Billing() {
         <Card>
           <CardHeader
             label="Active"
-            title={PLANS.find((p) => p.tier === payment.plan)?.label ?? payment.plan ?? 'Subscription'}
+            title={PLANS.find((p) => p.tier === normalizeTier(payment.plan))?.label ?? payment.plan ?? 'Subscription'}
             meta={
               payment.current_period_end
                 ? `${payment.cancel_at_period_end ? 'Ends' : 'Renews'} ${new Date(payment.current_period_end).toLocaleDateString()}`
@@ -186,7 +191,7 @@ export default function Billing() {
         </p>
       </section>
 
-      <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-4">
+      <section className="grid grid-cols-1 gap-4 md:grid-cols-2 xl:grid-cols-3">
         {PLANS.map((p) => {
           const annual = annualEffective(p.monthly);
           const price = interval === 'annual' ? annual : p.monthly;
@@ -217,7 +222,8 @@ export default function Billing() {
                   ${annual}/yr on annual
                 </div>
               )}
-              <p className="mt-4 text-sm text-ink">{p.headline}</p>
+              <div className="mt-3 text-xs uppercase tracking-widest2 text-faint">{p.model}</div>
+              <p className="mt-3 text-sm text-ink">{p.headline}</p>
               <ul className="mt-4 flex-1 space-y-2 text-sm text-mute">
                 {p.features.map((f) => (
                   <li key={f} className="flex items-start gap-2">

--- a/src/pages/client/Calendar.jsx
+++ b/src/pages/client/Calendar.jsx
@@ -1,119 +1,264 @@
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useAuth } from '../../context/AuthContext';
 import { supabase, isSupabaseConfigured } from '../../lib/supabaseClient';
+import {
+  addDays,
+  endOfMonth,
+  formatRange,
+  startOfMonth,
+  startOfWeek,
+  ymd,
+} from '../../lib/dateUtils';
+import { MonthGrid } from '../../components/calendar/MonthGrid';
+import { WeekStrip } from '../../components/calendar/WeekStrip';
+import { DayAgenda } from '../../components/calendar/DayAgenda';
 
-function startOfMonth(d) {
-  return new Date(d.getFullYear(), d.getMonth(), 1);
+const VIEWS = ['month', 'week', 'day'];
+
+function viewWindow(view, cursor) {
+  if (view === 'month') {
+    // Pad to the surrounding 6-week grid so leading/trailing cells are
+    // populated when the user pages backward or forward.
+    const first = startOfMonth(cursor);
+    const last = endOfMonth(cursor);
+    return [addDays(startOfWeek(first), -7), addDays(last, 14)];
+  }
+  if (view === 'week') {
+    const start = startOfWeek(cursor);
+    return [start, addDays(start, 7)];
+  }
+  return [cursor, addDays(cursor, 1)];
 }
-function daysInMonth(d) {
-  return new Date(d.getFullYear(), d.getMonth() + 1, 0).getDate();
+
+function navStep(view, cursor, direction) {
+  if (view === 'month') return new Date(cursor.getFullYear(), cursor.getMonth() + direction, 1);
+  if (view === 'week') return addDays(cursor, 7 * direction);
+  return addDays(cursor, direction);
 }
 
 export default function Calendar() {
   const { user } = useAuth();
+  const [view, setView] = useState('month');
   const [cursor, setCursor] = useState(new Date());
+  const [sessions, setSessions] = useState([]);
+  const [meals, setMeals] = useState([]);
+  const [habits, setHabits] = useState(null);
   const [checkIns, setCheckIns] = useState([]);
   const [programs, setPrograms] = useState([]);
 
-  useEffect(() => {
+  const [from, to] = viewWindow(view, cursor);
+  const fromIso = from.toISOString();
+  const toIso = to.toISOString();
+  const fromYmd = ymd(from);
+  const toYmd = ymd(to);
+
+  const reload = useCallback(async () => {
     if (!isSupabaseConfigured || !user) return;
-    const from = startOfMonth(cursor).toISOString();
-    const to = new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1).toISOString();
+    const [sess, mealRows, habitRow, ci, progs] = await Promise.all([
+      supabase
+        .from('workout_sessions')
+        .select('*')
+        .eq('client_id', user.id)
+        .or(
+          `and(performed_at.gte.${fromIso},performed_at.lt.${toIso}),and(scheduled_for.gte.${fromIso},scheduled_for.lt.${toIso})`,
+        ),
+      supabase
+        .from('meals')
+        .select('*')
+        .eq('client_id', user.id)
+        .gte('date', fromYmd)
+        .lt('date', toYmd),
+      supabase
+        .from('habits')
+        .select('*')
+        .eq('client_id', user.id)
+        .order('created_at', { ascending: false })
+        .limit(1)
+        .maybeSingle(),
+      supabase
+        .from('check_ins')
+        .select('*')
+        .eq('client_id', user.id)
+        .gte('date', fromYmd)
+        .lt('date', toYmd),
+      supabase
+        .from('programs')
+        .select('*')
+        .eq('client_id', user.id)
+        .eq('status', 'active'),
+    ]);
+    setSessions(sess.data ?? []);
+    setMeals(mealRows.data ?? []);
+    setHabits(habitRow.data ?? null);
+    setCheckIns(ci.data ?? []);
+    setPrograms(progs.data ?? []);
+  }, [user?.id, fromIso, toIso, fromYmd, toYmd]);
 
-    supabase
-      .from('check_ins')
-      .select('*')
-      .eq('client_id', user.id)
-      .gte('date', from)
-      .lt('date', to)
-      .then(({ data }) => setCheckIns(data ?? []));
+  useEffect(() => { reload(); }, [reload]);
 
-    supabase
-      .from('programs')
-      .select('*')
-      .eq('client_id', user.id)
-      .gte('created_at', from)
-      .lt('created_at', to)
-      .then(({ data }) => setPrograms(data ?? []));
-  }, [user?.id, cursor]);
+  const eventsByDay = useMemo(() => {
+    const map = {};
+    function push(key, ev) {
+      (map[key] ??= []).push(ev);
+    }
+    for (const s of sessions) {
+      const when = s.scheduled_for ?? s.performed_at;
+      if (!when) continue;
+      const date = new Date(when);
+      const status = s.performed_at ? 'logged' : 'planned';
+      push(ymd(date), {
+        id: s.id,
+        type: 'workout',
+        label: status === 'logged' ? 'Trained' : 'Lift',
+        time: date.toLocaleTimeString([], { hour: 'numeric', minute: '2-digit' }),
+        title: s.notes ?? '',
+        draggable: status === 'planned',
+        sourceDate: ymd(date),
+      });
+    }
+    for (const m of meals) {
+      if (!m.date) continue;
+      push(m.date, {
+        id: m.id,
+        type: 'meal',
+        label: m.meal_type ?? 'Meal',
+        title: (m.items ?? []).map((i) => (typeof i === 'string' ? i : i.name)).join(', '),
+        detail: m.macros?.kcal ? `${m.macros.kcal} kcal` : null,
+      });
+    }
+    for (const c of checkIns) {
+      if (!c.date) continue;
+      push(c.date, {
+        id: c.id,
+        type: 'check_in',
+        label: 'Check-in',
+        title: c.notes ?? '',
+        detail: c.weight ? `${c.weight} lb` : null,
+      });
+    }
+    if (habits?.check_history && typeof habits.check_history === 'object') {
+      for (const [date, checks] of Object.entries(habits.check_history)) {
+        if (date < fromYmd || date >= toYmd) continue;
+        const count = Array.isArray(checks)
+          ? checks.length
+          : Object.values(checks).filter(Boolean).length;
+        if (count > 0) {
+          push(date, {
+            id: `habit-${date}`,
+            type: 'habit',
+            label: `${count} habit${count === 1 ? '' : 's'}`,
+            detail: null,
+          });
+        }
+      }
+    }
+    for (const p of programs) {
+      const created = new Date(p.created_at);
+      push(ymd(created), {
+        id: p.id,
+        type: 'program',
+        label: p.schedule?.title ?? `Program W${p.week_number ?? 1}`,
+      });
+    }
+    return map;
+  }, [sessions, meals, checkIns, habits, programs, fromYmd, toYmd]);
 
-  const cells = useMemo(() => {
-    const first = startOfMonth(cursor);
-    const pad = first.getDay();
-    const total = daysInMonth(cursor);
-    const cells = [];
-    for (let i = 0; i < pad; i += 1) cells.push(null);
-    for (let d = 1; d <= total; d += 1) cells.push(new Date(cursor.getFullYear(), cursor.getMonth(), d));
-    return cells;
-  }, [cursor]);
+  async function handleDrop(event, day) {
+    if (event.type !== 'workout' || !event.draggable) return;
+    const target = new Date(day.getFullYear(), day.getMonth(), day.getDate(), 9, 0, 0);
+    // Optimistic update — patch local state, then write through.
+    setSessions((rows) =>
+      rows.map((r) => (r.id === event.id ? { ...r, scheduled_for: target.toISOString() } : r)),
+    );
+    const { error } = await supabase
+      .from('workout_sessions')
+      .update({ scheduled_for: target.toISOString() })
+      .eq('id', event.id);
+    if (error) reload();
+  }
 
-  const byDate = (date) => {
-    const key = date.toISOString().slice(0, 10);
-    const ci = checkIns.filter((c) => c.date?.startsWith(key));
-    const pr = programs.filter((p) => p.created_at?.startsWith(key));
-    return { ci, pr };
-  };
-
-  const monthLabel = cursor.toLocaleString(undefined, { month: 'long', year: 'numeric' });
+  function nudge(direction) {
+    setCursor(navStep(view, cursor, direction));
+  }
 
   return (
-    <div className="space-y-6">
-      <header className="flex items-end justify-between">
+    <div className="space-y-5">
+      <header className="flex flex-wrap items-end justify-between gap-3">
         <div>
           <div className="label mb-2">Calendar</div>
-          <h1 className="font-display text-4xl tracking-wider2">{monthLabel}</h1>
+          <h1 className="font-display text-4xl tracking-wider2 text-gold">
+            {formatRange(view, cursor)}
+          </h1>
         </div>
-        <div className="flex gap-2">
-          <button
-            type="button"
-            aria-label="Previous month"
-            onClick={() => setCursor(new Date(cursor.getFullYear(), cursor.getMonth() - 1, 1))}
-            className="border border-line px-3 py-2 text-xs uppercase tracking-widest2 text-mute hover:border-gold focus-visible:outline focus-visible:outline-1 focus-visible:outline-gold"
-          >
-            Prev
-          </button>
-          <button
-            type="button"
-            aria-label="Jump to current month"
-            onClick={() => setCursor(new Date())}
-            className="border border-line px-3 py-2 text-xs uppercase tracking-widest2 text-mute hover:border-gold focus-visible:outline focus-visible:outline-1 focus-visible:outline-gold"
-          >
-            Today
-          </button>
-          <button
-            type="button"
-            aria-label="Next month"
-            onClick={() => setCursor(new Date(cursor.getFullYear(), cursor.getMonth() + 1, 1))}
-            className="border border-line px-3 py-2 text-xs uppercase tracking-widest2 text-mute hover:border-gold focus-visible:outline focus-visible:outline-1 focus-visible:outline-gold"
-          >
-            Next
-          </button>
+        <div className="flex flex-wrap items-center gap-2">
+          <div role="tablist" aria-label="View" className="inline-flex border border-line">
+            {VIEWS.map((v) => (
+              <button
+                key={v}
+                type="button"
+                role="tab"
+                aria-selected={view === v}
+                onClick={() => setView(v)}
+                className={`px-3 py-2 text-[0.65rem] uppercase tracking-widest2 transition-colors ${
+                  view === v ? 'bg-gold text-bg' : 'text-mute hover:text-ink'
+                }`}
+              >
+                {v}
+              </button>
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => nudge(-1)}
+              aria-label={`Previous ${view}`}
+              className="border border-line px-3 py-2 text-[0.65rem] uppercase tracking-widest2 text-mute hover:border-gold focus-visible:outline focus-visible:outline-1 focus-visible:outline-gold"
+            >
+              Prev
+            </button>
+            <button
+              type="button"
+              onClick={() => setCursor(new Date())}
+              className="border border-line px-3 py-2 text-[0.65rem] uppercase tracking-widest2 text-mute hover:border-gold focus-visible:outline focus-visible:outline-1 focus-visible:outline-gold"
+            >
+              Today
+            </button>
+            <button
+              type="button"
+              onClick={() => nudge(1)}
+              aria-label={`Next ${view}`}
+              className="border border-line px-3 py-2 text-[0.65rem] uppercase tracking-widest2 text-mute hover:border-gold focus-visible:outline focus-visible:outline-1 focus-visible:outline-gold"
+            >
+              Next
+            </button>
+          </div>
         </div>
       </header>
 
-      <div className="grid grid-cols-7 gap-px bg-line">
-        {['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'].map((d) => (
-          <div key={d} className="bg-bg py-2 text-center text-[0.65rem] uppercase tracking-widest2 text-faint">
-            {d}
-          </div>
-        ))}
-        {cells.map((date, i) => {
-          if (!date) return <div key={`pad-${i}`} className="aspect-square bg-bg/60" />;
-          const { ci, pr } = byDate(date);
-          const isToday = date.toDateString() === new Date().toDateString();
-          return (
-            <div key={date.toISOString()} className={`aspect-square bg-bg p-2 ${isToday ? 'ring-1 ring-gold' : ''}`}>
-              <div className="text-xs text-faint">{date.getDate()}</div>
-              {ci.length > 0 ? <div className="mt-1 h-1 w-6 bg-gold" title="Check-in" /> : null}
-              {pr.length > 0 ? <div className="mt-1 h-1 w-6 bg-ink/60" title="Program" /> : null}
-            </div>
-          );
-        })}
-      </div>
+      {view === 'month' ? (
+        <MonthGrid
+          cursor={cursor}
+          eventsByDay={eventsByDay}
+          onSelectDay={(d) => { setCursor(d); setView('day'); }}
+          onDropOnDay={handleDrop}
+        />
+      ) : view === 'week' ? (
+        <WeekStrip
+          cursor={cursor}
+          eventsByDay={eventsByDay}
+          onSelectDay={(d) => { setCursor(d); setView('day'); }}
+          onDropOnDay={handleDrop}
+        />
+      ) : (
+        <DayAgenda cursor={cursor} eventsByDay={eventsByDay} onDropOnDay={handleDrop} />
+      )}
 
-      <div className="flex gap-6 text-xs uppercase tracking-widest2 text-faint">
-        <span className="flex items-center gap-2"><span className="inline-block h-1 w-6 bg-gold" /> Check-in</span>
-        <span className="flex items-center gap-2"><span className="inline-block h-1 w-6 bg-ink/60" /> Program</span>
+      <div className="flex flex-wrap gap-4 text-[0.6rem] uppercase tracking-widest2 text-faint">
+        <span className="flex items-center gap-2"><span className="inline-block h-2 w-3 border border-gold/60 bg-gold/15" /> Lift</span>
+        <span className="flex items-center gap-2"><span className="inline-block h-2 w-3 border border-line bg-black/40" /> Meal</span>
+        <span className="flex items-center gap-2"><span className="inline-block h-2 w-3 border border-success/60 bg-success/15" /> Habit</span>
+        <span className="flex items-center gap-2"><span className="inline-block h-2 w-3 border border-signal/60 bg-signal/15" /> Check-in</span>
+        <span className="flex items-center gap-2"><span className="inline-block h-2 w-3 border border-line text-faint" /> Program</span>
       </div>
     </div>
   );

--- a/src/pages/client/Import.jsx
+++ b/src/pages/client/Import.jsx
@@ -1,0 +1,89 @@
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import { Upload } from 'lucide-react';
+import { apify } from '../../lib/claudeClient';
+import { Button } from '../../components/ui/Button';
+import { Input } from '../../components/ui/Input';
+
+export default function Import() {
+  const [url, setUrl] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [status, setStatus] = useState(null);
+  const [err, setErr] = useState(null);
+  const [imported, setImported] = useState(null);
+
+  async function go(e) {
+    e.preventDefault();
+    setBusy(true);
+    setErr(null);
+    setImported(null);
+    setStatus('Starting import…');
+    try {
+      const res = await apify.importTrainerize(url.trim());
+      if (res?.program) {
+        setImported(res.program);
+        setStatus('Imported. Review it under Workouts.');
+      } else if (res?.runId) {
+        setStatus(`Import is still running (${res.status}). Run id: ${res.runId}. Try again in a minute.`);
+      } else {
+        setStatus('Done.');
+      }
+    } catch (e) {
+      setErr(e.message);
+      setStatus(null);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <header>
+        <div className="label mb-2">Import</div>
+        <h1 className="font-display text-4xl tracking-wider2 text-gold">Trainerize program</h1>
+        <p className="mt-2 max-w-reading text-sm text-mute">
+          Paste the URL of your Trainerize program. The system runs an Apify scraper, pulls the
+          schedule and exercises, and lands the result as a draft under Workouts. You can publish it
+          from there.
+        </p>
+      </header>
+
+      <form onSubmit={go} className="space-y-4">
+        <Input
+          label="Trainerize program URL"
+          type="url"
+          required
+          placeholder="https://www.trainerize.com/profile/..."
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+        />
+        <div className="flex flex-wrap items-center gap-3">
+          <Button disabled={busy || !url.trim()}>
+            <Upload size={14} className="mr-2" /> {busy ? 'Importing' : 'Import program'}
+          </Button>
+          {status ? (
+            <span className="text-xs uppercase tracking-widest2 text-mute">{status}</span>
+          ) : null}
+          {err ? (
+            <span role="alert" className="text-xs uppercase tracking-widest2 text-signal">{err}</span>
+          ) : null}
+        </div>
+      </form>
+
+      {imported ? (
+        <div className="border border-line bg-black/30 p-5">
+          <div className="label mb-2">Imported draft</div>
+          <div className="font-display text-xl tracking-wider2">
+            {imported.schedule?.title ?? `Program W${imported.week_number ?? 1}`}
+          </div>
+          <div className="mt-1 text-xs uppercase tracking-widest2 text-faint">
+            {(imported.exercises ?? []).length} exercise{(imported.exercises ?? []).length === 1 ? '' : 's'}
+          </div>
+          <div className="mt-3 flex gap-2">
+            <Button as={Link} to="/workouts" variant="ghost">Open Workouts</Button>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/pages/client/Meals.jsx
+++ b/src/pages/client/Meals.jsx
@@ -1,9 +1,11 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
+import { Camera } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { supabase, isSupabaseConfigured } from '../../lib/supabaseClient';
 import { Button } from '../../components/ui/Button';
 import { Empty } from '../../components/ui/Empty';
+import { SnapMealModal } from '../../components/SnapMealModal';
 
 function totals(items) {
   const planned = { kcal: 0, p: 0, c: 0, f: 0 };
@@ -67,6 +69,7 @@ export default function Meals() {
   const { user, profile } = useAuth();
   const [meals, setMeals] = useState([]);
   const [loading, setLoading] = useState(true);
+  const [snapOpen, setSnapOpen] = useState(false);
 
   const floor = useMemo(
     () => ({
@@ -93,6 +96,23 @@ export default function Meals() {
   }, [user?.id]);
 
   useEffect(() => { load(); }, [load]);
+
+  async function logSnap(payload) {
+    if (!user) return;
+    const today = new Date().toISOString().slice(0, 10);
+    const row = {
+      client_id: user.id,
+      day: today,
+      date: today,
+      meal_type: payload.meal_type ?? 'meal',
+      items: payload.items ?? [],
+      macros: payload.macros ?? {},
+      eaten: true,
+      eaten_at: new Date().toISOString(),
+    };
+    const { data, error } = await supabase.from('meals').insert(row).select().maybeSingle();
+    if (!error && data) setMeals((list) => [data, ...list]);
+  }
 
   async function toggleEaten(meal) {
     const next = !meal.eaten;
@@ -149,8 +169,19 @@ export default function Meals() {
           <div className="label mb-2">Nutrition</div>
           <h1 className="font-display text-4xl tracking-wider2">Meal plan</h1>
         </div>
-        <Button as={Link} to="/meals/generator">AI Meal plan</Button>
+        <div className="flex flex-wrap gap-2">
+          <Button variant="ghost" onClick={() => setSnapOpen(true)}>
+            <Camera size={14} className="mr-2" /> Snap a meal
+          </Button>
+          <Button as={Link} to="/meals/generator">AI Meal plan</Button>
+        </div>
       </header>
+
+      <SnapMealModal
+        open={snapOpen}
+        onClose={() => setSnapOpen(false)}
+        onConfirm={logSnap}
+      />
 
       {loading ? (
         <div className="text-xs uppercase tracking-widest2 text-faint">Loading</div>

--- a/src/pages/client/Profile.jsx
+++ b/src/pages/client/Profile.jsx
@@ -8,6 +8,7 @@ import { Input } from '../../components/ui/Input';
 import { Avatar } from '../../components/ui/Avatar';
 import { StorageImage } from '../../components/StorageImage';
 import { Card, CardHeader } from '../../components/ui/Card';
+import { IntakePanel } from '../../components/IntakePanel';
 import { formatWeight, formatWeightDelta, kgToLbs, parseWeightToKg, weightLabel } from '../../lib/units';
 
 export default function Profile() {
@@ -301,6 +302,8 @@ export default function Profile() {
           {profileErr ? <span role="alert" className="text-xs uppercase tracking-widest2 text-signal">{profileErr}</span> : null}
         </div>
       </form>
+
+      <IntakePanel profile={profile} />
 
       <section>
         <div className="label mb-2">Weekly check-in</div>

--- a/src/pages/client/Workouts.jsx
+++ b/src/pages/client/Workouts.jsx
@@ -15,9 +15,22 @@ function parseYouTubeId(input = '') {
   return m?.[1] ?? (input.length === 11 ? input : null);
 }
 
-function ExerciseRow({ ex }) {
+// kebab-case slug for the curated exercise_videos lookup. Strips parens,
+// trims trailing variants, lowercases. e.g. "Back Squat (paused)" → "back-squat".
+function exerciseSlug(name = '') {
+  return String(name)
+    .toLowerCase()
+    .replace(/\(.+?\)/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .trim();
+}
+
+function ExerciseRow({ ex, videoLibrary }) {
   const [open, setOpen] = useState(false);
-  const videoId = parseYouTubeId(ex.youtube);
+  const inlineId = parseYouTubeId(ex.youtube);
+  const fallbackId = videoLibrary?.[exerciseSlug(ex.name ?? ex.title ?? '')] ?? null;
+  const videoId = inlineId ?? fallbackId;
   const note = ex.cues || ex.notes;
 
   return (
@@ -61,7 +74,7 @@ function ExerciseRow({ ex }) {
   );
 }
 
-function ProgramCard({ program, sessionCount, onLog, onArchive, onReactivate }) {
+function ProgramCard({ program, sessionCount, onLog, onArchive, onReactivate, videoLibrary }) {
   const [open, setOpen] = useState(false);
 
   const exercises = Array.isArray(program.exercises) ? program.exercises : [];
@@ -111,7 +124,7 @@ function ProgramCard({ program, sessionCount, onLog, onArchive, onReactivate }) 
       ) : (
         <ul>
           {exercises.map((e, i) => (
-            <ExerciseRow key={i} ex={e} />
+            <ExerciseRow key={i} ex={e} videoLibrary={videoLibrary} />
           ))}
         </ul>
       )}
@@ -136,6 +149,21 @@ export default function Workouts() {
   const [sessions, setSessions] = useState([]);
   const [loading, setLoading] = useState(true);
   const [filter, setFilter] = useState('active');
+  const [videoLibrary, setVideoLibrary] = useState({});
+
+  // Curated demo videos: slug → youtube_id. Loaded once and used as a
+  // fallback when an exercise row lacks an inline `youtube` field.
+  useEffect(() => {
+    if (!isSupabaseConfigured) return;
+    supabase
+      .from('exercise_videos')
+      .select('slug,youtube_id')
+      .then(({ data }) => {
+        const map = {};
+        for (const row of data ?? []) map[row.slug] = row.youtube_id;
+        setVideoLibrary(map);
+      });
+  }, []);
 
   const load = useCallback(async () => {
     if (!isSupabaseConfigured || !user) {
@@ -247,6 +275,7 @@ export default function Workouts() {
                 onLog={logSession}
                 onArchive={archiveProgram}
                 onReactivate={reactivateProgram}
+                videoLibrary={videoLibrary}
               />
             ))}
           </div>

--- a/src/pages/legal/Coaching.jsx
+++ b/src/pages/legal/Coaching.jsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom';
+import coachingSource from '../../content/legal/coaching.md?raw';
+import { MarkdownDoc } from '../../components/MarkdownDoc';
+
+export default function Coaching() {
+  return (
+    <div className="mx-auto max-w-reading px-5 py-12">
+      <Link to="/" className="label mb-6 inline-block">← Back</Link>
+      <MarkdownDoc source={coachingSource} />
+    </div>
+  );
+}

--- a/src/pages/legal/Privacy.jsx
+++ b/src/pages/legal/Privacy.jsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom';
+import privacySource from '../../content/legal/privacy.md?raw';
+import { MarkdownDoc } from '../../components/MarkdownDoc';
+
+export default function Privacy() {
+  return (
+    <div className="mx-auto max-w-reading px-5 py-12">
+      <Link to="/" className="label mb-6 inline-block">← Back</Link>
+      <MarkdownDoc source={privacySource} />
+    </div>
+  );
+}

--- a/src/pages/legal/Terms.jsx
+++ b/src/pages/legal/Terms.jsx
@@ -1,0 +1,12 @@
+import { Link } from 'react-router-dom';
+import termsSource from '../../content/legal/terms.md?raw';
+import { MarkdownDoc } from '../../components/MarkdownDoc';
+
+export default function Terms() {
+  return (
+    <div className="mx-auto max-w-reading px-5 py-12">
+      <Link to="/" className="label mb-6 inline-block">← Back</Link>
+      <MarkdownDoc source={termsSource} />
+    </div>
+  );
+}

--- a/src/pages/owner/ImageLab.jsx
+++ b/src/pages/owner/ImageLab.jsx
@@ -1,0 +1,188 @@
+import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { ArrowLeft, Sparkles, Download } from 'lucide-react';
+import { useAuth } from '../../context/AuthContext';
+import { images } from '../../lib/claudeClient';
+import { Button } from '../../components/ui/Button';
+
+// Owner-only fal.ai surface. Wraps the existing /generate-image function
+// with a prompt + model picker. Cost is logged server-side via fal_usage.
+
+const MODELS = [
+  { id: 'flux-schnell', label: 'Flux schnell · fast, cheap' },
+  { id: 'flux-dev',     label: 'Flux dev · balanced' },
+  { id: 'flux-pro',     label: 'Flux pro · highest fidelity' },
+];
+
+const ASPECTS = ['1:1', '16:9', '9:16', '1080:1350'];
+
+export default function ImageLab() {
+  const { role } = useAuth();
+  const nav = useNavigate();
+  const [prompt, setPrompt] = useState('');
+  const [stylePrompt, setStylePrompt] = useState('');
+  const [model, setModel] = useState('flux-schnell');
+  const [aspect, setAspect] = useState('1:1');
+  const [count, setCount] = useState(1);
+  const [busy, setBusy] = useState(false);
+  const [results, setResults] = useState([]);
+  const [usage, setUsage] = useState(null);
+  const [err, setErr] = useState(null);
+
+  if (role !== 'owner') {
+    return (
+      <div className="mx-auto max-w-reading p-10">
+        <h1 className="font-display text-3xl tracking-wider2 text-gold">Owner only</h1>
+        <p className="mt-3 text-sm text-mute">
+          Image Lab is gated by OWNER_EMAILS. Contact the operator if you need access.
+        </p>
+      </div>
+    );
+  }
+
+  async function go(e) {
+    e.preventDefault();
+    if (!prompt.trim()) return;
+    setBusy(true);
+    setErr(null);
+    try {
+      const res = await images.generate({
+        prompt: prompt.trim(),
+        model,
+        aspect_ratio: aspect,
+        num_images: count,
+        style_prompt: stylePrompt.trim() || undefined,
+      });
+      setResults(res.images ?? []);
+      setUsage(res.usage ?? null);
+    } catch (ex) {
+      setErr(ex.message);
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen bg-bg text-ink">
+      <header className="mx-auto flex max-w-4xl items-center justify-between px-6 pt-10 pb-6">
+        <button
+          type="button"
+          onClick={() => nav('/owner')}
+          className="flex items-center gap-2 text-mute transition-colors hover:text-gold"
+        >
+          <ArrowLeft size={16} />
+          <span className="text-xs uppercase tracking-widest2">Owner</span>
+        </button>
+        <div className="text-right">
+          <div className="label">Image Lab</div>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-4xl px-6 pb-24">
+        <h1 className="font-display text-4xl tracking-wider2 text-gold sm:text-5xl">
+          Generate
+        </h1>
+        <p className="mt-3 max-w-reading text-sm text-mute">
+          fal.ai Flux. Cost is tracked per call in fal_usage. ATLAS brand style is the default —
+          override style_prompt for a different look.
+        </p>
+
+        <form onSubmit={go} className="mt-8 space-y-4">
+          <label className="flex flex-col gap-1">
+            <span className="label">Prompt</span>
+            <textarea
+              rows={3}
+              value={prompt}
+              onChange={(e) => setPrompt(e.target.value)}
+              placeholder="Describe the image. Composition, subject, mood."
+              className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+            />
+          </label>
+          <label className="flex flex-col gap-1">
+            <span className="label">Style prompt (optional)</span>
+            <textarea
+              rows={2}
+              value={stylePrompt}
+              onChange={(e) => setStylePrompt(e.target.value)}
+              placeholder="Override the ATLAS default. Examples: photorealistic, editorial, cinematic."
+              className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+            />
+          </label>
+          <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+            <label className="flex flex-col gap-1">
+              <span className="label">Model</span>
+              <select
+                value={model}
+                onChange={(e) => setModel(e.target.value)}
+                className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+              >
+                {MODELS.map((m) => (
+                  <option key={m.id} value={m.id}>{m.label}</option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="label">Aspect</span>
+              <select
+                value={aspect}
+                onChange={(e) => setAspect(e.target.value)}
+                className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+              >
+                {ASPECTS.map((a) => (
+                  <option key={a} value={a}>{a}</option>
+                ))}
+              </select>
+            </label>
+            <label className="flex flex-col gap-1">
+              <span className="label">Count</span>
+              <select
+                value={count}
+                onChange={(e) => setCount(Number(e.target.value))}
+                className="border border-line bg-black/40 px-3 py-2 text-sm text-ink focus:border-gold"
+              >
+                {[1, 2, 3, 4].map((n) => (
+                  <option key={n} value={n}>{n}</option>
+                ))}
+              </select>
+            </label>
+          </div>
+          <div className="flex flex-wrap items-center gap-3">
+            <Button disabled={busy || !prompt.trim()}>
+              <Sparkles size={14} className="mr-2" /> {busy ? 'Generating' : 'Generate'}
+            </Button>
+            {usage ? (
+              <span className="text-[0.65rem] uppercase tracking-widest2 text-faint">
+                Last call: ${usage.cost_usd?.toFixed(4)} · {usage.model}
+              </span>
+            ) : null}
+            {err ? (
+              <span role="alert" className="text-xs uppercase tracking-widest2 text-signal">{err}</span>
+            ) : null}
+          </div>
+        </form>
+
+        {results.length > 0 ? (
+          <section className="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-2">
+            {results.map((img, i) => (
+              <figure key={i} className="border border-line bg-black/30">
+                <img src={img.url} alt={`Generated ${i + 1}`} className="w-full" />
+                <figcaption className="flex items-center justify-between border-t border-line px-3 py-2 text-[0.6rem] uppercase tracking-widest2 text-faint">
+                  <span>{img.width}×{img.height}</span>
+                  <a
+                    href={img.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    download
+                    className="flex items-center gap-1 text-gold hover:underline"
+                  >
+                    <Download size={12} /> Open
+                  </a>
+                </figcaption>
+              </figure>
+            ))}
+          </section>
+        ) : null}
+      </main>
+    </div>
+  );
+}

--- a/supabase/migrations/0027_tier_simplification.sql
+++ b/supabase/migrations/0027_tier_simplification.sql
@@ -1,0 +1,43 @@
+-- Tier simplification + BYO Anthropic key column.
+--
+-- Replaces the legacy 4-tier structure (performance / identity / full /
+-- premium) with three model-aware tiers (tier1 = Haiku, tier2 = Sonnet,
+-- tier3 = Opus). Tier 3 subscribers can paste their own Anthropic API key,
+-- which is stored AES-GCM encrypted at the application layer.
+
+-- 1. Add the encrypted BYO key column. Plain bytea — encryption is performed
+--    by netlify/functions/_shared/byo-crypto.js using BYO_KEY_SECRET. Storing
+--    encrypted bytes (rather than plaintext) means a Postgres or Supabase
+--    breach alone is not sufficient to leak Anthropic credentials.
+alter table public.profiles
+  add column if not exists byo_anthropic_key_encrypted bytea;
+
+comment on column public.profiles.byo_anthropic_key_encrypted is
+  'AES-256-GCM encrypted Anthropic API key for tier3 BYO option. IV(12)||tag(16)||ct.';
+
+-- 2. Backfill legacy plan strings to the new tier names. Mapping rule:
+--      performance -> tier1   (matches Haiku price point)
+--      identity    -> tier1   (rolls up to closest active tier)
+--      full        -> tier2   (Sonnet)
+--      premium     -> tier3   (Opus)
+--    Existing Stripe subscriptions stay live until renewal; the webhook keeps
+--    legacy price IDs mapped to the same target tiers (see stripe-webhook.js).
+update public.profiles
+  set plan = case plan
+    when 'performance' then 'tier1'
+    when 'identity'    then 'tier1'
+    when 'full'        then 'tier2'
+    when 'premium'     then 'tier3'
+    else plan
+  end
+  where plan in ('performance', 'identity', 'full', 'premium');
+
+update public.payments
+  set plan = case plan
+    when 'performance' then 'tier1'
+    when 'identity'    then 'tier1'
+    when 'full'        then 'tier2'
+    when 'premium'     then 'tier3'
+    else plan
+  end
+  where plan in ('performance', 'identity', 'full', 'premium');

--- a/supabase/migrations/0028_calendar_scheduled.sql
+++ b/supabase/migrations/0028_calendar_scheduled.sql
@@ -1,0 +1,28 @@
+-- Calendar: separate scheduling from logging.
+--
+-- workout_sessions.performed_at marks when a session was actually completed.
+-- A planned-but-not-yet-done session has no logical home in the existing
+-- schema. Adding a nullable scheduled_for lets the Apple-style calendar
+-- show planned sessions, drag-to-reschedule them, and convert a planned
+-- session to a logged one when performed_at is filled in.
+--
+-- Existing rows keep performed_at; scheduled_for is null for backfill.
+
+alter table public.workout_sessions
+  add column if not exists scheduled_for timestamptz;
+
+comment on column public.workout_sessions.scheduled_for is
+  'Planned start time. Drag-to-reschedule on the Calendar updates this. ' ||
+  'A row with scheduled_for set and performed_at null is a planned session; ' ||
+  'with both set it is a completed session.';
+
+create index if not exists workout_sessions_scheduled_idx
+  on public.workout_sessions (client_id, scheduled_for)
+  where scheduled_for is not null;
+
+-- Speed up date-bounded reads from the calendar.
+create index if not exists meals_client_date_idx
+  on public.meals (client_id, date);
+
+create index if not exists check_ins_client_date_idx
+  on public.check_ins (client_id, date);

--- a/supabase/migrations/0029_profile_intake_legal.sql
+++ b/supabase/migrations/0029_profile_intake_legal.sql
@@ -1,0 +1,32 @@
+-- Profile intake + legal consent + emergency contact.
+--
+-- Three new JSONB columns on `profiles`:
+--   intake             — non-sensitive personal data (legal name, address,
+--                        DOB, sex, height_cm, weight_lb, occupation, training
+--                        background, goals, training days/week, equipment).
+--   medical_encrypted  — bytea ciphertext of the JSON medical block
+--                        (conditions, medications, allergies, injuries,
+--                        emergency_contact). AES-256-GCM keyed by
+--                        MEDICAL_ENC_SECRET. Server-side only — clients
+--                        read/write through update-profile / get-my-medical
+--                        Netlify functions, never directly via supabase-js.
+--   consent            — { tos_v: int, coaching_v: int, privacy_v: int,
+--                          signed_at: timestamp, ip?: text, ua?: text }.
+--
+-- The profiles_lock_privileged trigger already prevents clients from
+-- self-promoting role/plan/loop_stage/start_date; the new columns are not
+-- privileged so client UPDATEs that touch them go through (subject to RLS).
+-- We still funnel writes through update-profile.js so the medical block can
+-- be encrypted before storage.
+
+alter table public.profiles
+  add column if not exists intake jsonb,
+  add column if not exists medical_encrypted bytea,
+  add column if not exists consent jsonb;
+
+comment on column public.profiles.intake is
+  'Non-sensitive intake data: legal name, address, DOB, sex, height_cm, weight_lb, etc.';
+comment on column public.profiles.medical_encrypted is
+  'AES-256-GCM ciphertext (IV(12)||tag(16)||ct) of the medical JSON block. Keyed by MEDICAL_ENC_SECRET server env.';
+comment on column public.profiles.consent is
+  'Versioned consent record: { tos_v, coaching_v, privacy_v, signed_at }.';

--- a/supabase/migrations/0030_exercise_video_library.sql
+++ b/supabase/migrations/0030_exercise_video_library.sql
@@ -1,0 +1,71 @@
+-- Curated YouTube demo library. The workout generator may emit a `youtube`
+-- field per exercise, but consistent quality is hard to enforce in prompt
+-- alone. This table is the fallback: when a generated exercise lacks a
+-- video, the client looks up the slug and embeds the curated clip.
+--
+-- Slugs are kebab-case canonical names (back-squat, conventional-deadlift,
+-- bench-press). The workout-generator prompt is instructed to use these
+-- canonical names so a slug match hits the seed.
+--
+-- License note: each row should reference a public YouTube video whose
+-- channel terms allow embedding (most do — that's YouTube's default unless
+-- a creator opts out). Curate further as channels are reviewed.
+
+create table if not exists public.exercise_videos (
+  slug             text primary key,
+  name             text not null,
+  youtube_id       text not null,
+  source_channel   text,
+  license_note     text,
+  category         text,
+  created_at       timestamptz not null default now()
+);
+
+create index if not exists exercise_videos_category_idx
+  on public.exercise_videos (category);
+
+alter table public.exercise_videos enable row level security;
+
+-- Public read: everyone signed in (or not) can fetch the library so the
+-- client app can render demos without an extra RPC. No writes from the
+-- client app — curation happens via service role only.
+drop policy if exists "exercise_videos read" on public.exercise_videos;
+create policy "exercise_videos read" on public.exercise_videos
+  for select using (true);
+
+-- Seed: a small library of universal lifts. Channels chosen for permissive
+-- embed policies and high-quality form demonstrations. Replace any row by
+-- re-inserting with the same slug after a curation pass.
+insert into public.exercise_videos (slug, name, youtube_id, source_channel, license_note, category) values
+  ('back-squat',          'Back Squat',          'SW_C1A-rejs', 'Squat University', 'Public YouTube embed', 'lower'),
+  ('front-squat',         'Front Squat',         'tlfahNdNPPI', 'Squat University', 'Public YouTube embed', 'lower'),
+  ('conventional-deadlift','Conventional Deadlift','op9kVnSso6Q','Squat University', 'Public YouTube embed', 'lower'),
+  ('romanian-deadlift',   'Romanian Deadlift',   'JCXUYuzwNrM', 'Renaissance Periodization', 'Public YouTube embed', 'lower'),
+  ('bench-press',         'Bench Press',         'rT7DgCr-3pg', 'Athlean-X',         'Public YouTube embed', 'upper'),
+  ('overhead-press',      'Overhead Press',      'M2rwvNhTOu0', 'Athlean-X',         'Public YouTube embed', 'upper'),
+  ('barbell-row',         'Barbell Row',         'kBWAon7ItDw', 'Renaissance Periodization', 'Public YouTube embed', 'upper'),
+  ('pull-up',             'Pull-Up',             'eGo4IYlbE5g', 'Calisthenicmovement', 'Public YouTube embed', 'upper'),
+  ('chin-up',             'Chin-Up',             'b-ozIAv6JKo', 'Calisthenicmovement', 'Public YouTube embed', 'upper'),
+  ('dip',                 'Dip',                 '2z8JmcrW-As', 'Calisthenicmovement', 'Public YouTube embed', 'upper'),
+  ('lat-pulldown',        'Lat Pulldown',        'CAwf7n6Luuc', 'Renaissance Periodization', 'Public YouTube embed', 'upper'),
+  ('seated-cable-row',    'Seated Cable Row',    'sP_4vybjVJs', 'Renaissance Periodization', 'Public YouTube embed', 'upper'),
+  ('incline-dumbbell-press','Incline DB Press',  '8iPEnn-ltC8', 'Renaissance Periodization', 'Public YouTube embed', 'upper'),
+  ('dumbbell-bench-press','DB Bench Press',      'VmB1G1K7v94', 'Renaissance Periodization', 'Public YouTube embed', 'upper'),
+  ('lateral-raise',       'Lateral Raise',       '3VcKaXpzqRo', 'Renaissance Periodization', 'Public YouTube embed', 'upper'),
+  ('rear-delt-fly',       'Rear Delt Fly',       'A7W7C4hKDM4', 'Renaissance Periodization', 'Public YouTube embed', 'upper'),
+  ('face-pull',           'Face Pull',           'rep-qVOkqgk', 'Athlean-X',         'Public YouTube embed', 'upper'),
+  ('barbell-curl',        'Barbell Curl',        'kwG2ipFRgfo', 'Renaissance Periodization', 'Public YouTube embed', 'arms'),
+  ('hammer-curl',         'Hammer Curl',         'TwD-YGVP4Bk', 'Renaissance Periodization', 'Public YouTube embed', 'arms'),
+  ('triceps-pushdown',    'Triceps Pushdown',    '2-LAMcpzODU', 'Athlean-X',         'Public YouTube embed', 'arms'),
+  ('skullcrusher',        'Skullcrusher',        'd_KZxkY_0cM', 'Athlean-X',         'Public YouTube embed', 'arms'),
+  ('walking-lunge',       'Walking Lunge',       'wrwwXE_x-pQ', 'Squat University',  'Public YouTube embed', 'lower'),
+  ('bulgarian-split-squat','Bulgarian Split Squat','2C-uNgKwPLE','Squat University','Public YouTube embed', 'lower'),
+  ('hip-thrust',          'Hip Thrust',          'LM8XHLYJoYs', 'Bret Contreras',    'Public YouTube embed', 'lower'),
+  ('leg-press',           'Leg Press',           'IZxyjW7MPJQ', 'Renaissance Periodization', 'Public YouTube embed', 'lower'),
+  ('leg-curl',            'Leg Curl',            'F488k67BTNE', 'Renaissance Periodization', 'Public YouTube embed', 'lower'),
+  ('leg-extension',       'Leg Extension',       'm0FOpMEgero', 'Renaissance Periodization', 'Public YouTube embed', 'lower'),
+  ('calf-raise',          'Calf Raise',          'gwLzBJYoWlI', 'Renaissance Periodization', 'Public YouTube embed', 'lower'),
+  ('plank',               'Plank',               'pSHjTRCQxIw', 'Calisthenicmovement', 'Public YouTube embed', 'core'),
+  ('hanging-leg-raise',   'Hanging Leg Raise',   'Pr1ieGZ5atk', 'Calisthenicmovement', 'Public YouTube embed', 'core'),
+  ('ab-wheel-rollout',    'Ab Wheel Rollout',    'rqiTPdK1c_I', 'Athlean-X',         'Public YouTube embed', 'core')
+on conflict (slug) do nothing;

--- a/tests/client-assistant.test.js
+++ b/tests/client-assistant.test.js
@@ -24,6 +24,13 @@ vi.mock('../netlify/functions/_shared/anthropic.js', () => ({
   getAnthropic: () => anthropicMock,
   loadPrompt: () => 'system',
   MODEL: 'claude-test-model',
+  MODEL_BY_TIER: {
+    trial: 'claude-test-model',
+    tier1: 'claude-test-model',
+    tier2: 'claude-test-model',
+    tier3: 'claude-test-model',
+  },
+  pickModel: () => 'claude-test-model',
   sanitizeVoice: (t) => t,
   bannedTokensCleanup: (t) => (t ?? '').trim(),
 }));

--- a/tests/generate-meal-plan.test.js
+++ b/tests/generate-meal-plan.test.js
@@ -16,6 +16,13 @@ vi.mock('../netlify/functions/_shared/anthropic.js', () => ({
   getAnthropic: () => anthropicMock,
   loadPrompt: () => 'system',
   MODEL: 'claude-test-model',
+  MODEL_BY_TIER: {
+    trial: 'claude-test-model',
+    tier1: 'claude-test-model',
+    tier2: 'claude-test-model',
+    tier3: 'claude-test-model',
+  },
+  pickModel: () => 'claude-test-model',
   sanitizeVoice: (t) => t,
   bannedTokensCleanup: (t) => (t ?? '').trim(),
 }));

--- a/tests/generate-weekly-review.test.js
+++ b/tests/generate-weekly-review.test.js
@@ -16,6 +16,13 @@ vi.mock('../netlify/functions/_shared/anthropic.js', () => ({
   getAnthropic: () => anthropicMock,
   loadPrompt: () => 'system',
   MODEL: 'claude-test-model',
+  MODEL_BY_TIER: {
+    trial: 'claude-test-model',
+    tier1: 'claude-test-model',
+    tier2: 'claude-test-model',
+    tier3: 'claude-test-model',
+  },
+  pickModel: () => 'claude-test-model',
   sanitizeVoice: (t) => t,
   bannedTokensCleanup: (t) => (t ?? '').trim(),
 }));

--- a/tests/generate-workout.test.js
+++ b/tests/generate-workout.test.js
@@ -34,6 +34,13 @@ vi.mock('../netlify/functions/_shared/anthropic.js', () => ({
   getAnthropic: () => anthropicMock,
   loadPrompt: (...args) => loadPromptMock(...args),
   MODEL: 'claude-test-model',
+  MODEL_BY_TIER: {
+    trial: 'claude-test-model',
+    tier1: 'claude-test-model',
+    tier2: 'claude-test-model',
+    tier3: 'claude-test-model',
+  },
+  pickModel: () => 'claude-test-model',
   sanitizeVoice: (t) => t,
   bannedTokensCleanup: (t) => (t ?? '').trim(),
 }));

--- a/tests/stripe-webhook.test.js
+++ b/tests/stripe-webhook.test.js
@@ -269,7 +269,10 @@ describe('stripe-webhook', () => {
       expect(row.stripe_customer_id).toBe('cus_abc');
       expect(row.stripe_subscription_id).toBe('sub_xyz');
       expect(row.client_id).toBe('client-1');
-      expect(row.plan).toBe('performance');
+      // Legacy STRIPE_PRICE_PERFORMANCE_MONTHLY now maps to tier1 (the
+      // tier-simplification rollup). Subscription metadata.tier is ignored
+      // when a price ID resolves a tier — the price ID is the source of truth.
+      expect(row.plan).toBe('tier1');
       expect(row.status).toBe('active');
       expect(row.amount).toBe(250);
       expect(upsertCall.args[1]).toEqual({ onConflict: 'stripe_subscription_id' });
@@ -277,7 +280,7 @@ describe('stripe-webhook', () => {
       // Profile update happens because we have both client_id and a tier.
       const profileUpdate = supabaseMock.__calls.find((c) => c.method === 'profiles.update');
       expect(profileUpdate).toBeDefined();
-      expect(profileUpdate.args[0]).toEqual({ plan: 'performance' });
+      expect(profileUpdate.args[0]).toEqual({ plan: 'tier1' });
     });
 
     it('maps unknown subscription status values to incomplete', async () => {


### PR DESCRIPTION
## Summary

The full gap-closure plan, all six phases plus Owner Mode, stacked on a single branch.

## What's in this PR

### Phase A — Tier-aware Claude routing + 3-tier billing
- `tier1` $250 → Haiku 4.5, `tier2` $475 → Sonnet 4.6, `tier3` $750 → Opus 4.7
- Tier 3 BYO Anthropic key, AES-256-GCM encrypted at rest with `BYO_KEY_SECRET`
- Legacy 4 tiers (`performance`/`identity`/`full`/`premium`) auto-roll up via webhook + migration
- 3-card Billing UI lists which Claude model powers each tier

### Phase B — iPhone-style home screen + cinematic landing intro
- `/home` replaces `/dashboard` as the default post-login surface — squircle app icons, fixed bottom dock (Coach / Calendar / Profile), Today widget tile preserves Dashboard
- `<CinematicIntro />` on the public landing — plays `/trailer/pkfit-intro.mp4` if present, else falls back to a Bebas Neue typography reveal with the "Powered by /operate/axiom" tagline. Skippable, localStorage-cached
- `scripts/generate-trailer.js` is a one-shot fal.ai veo3 generator; runtime never calls fal.ai for the trailer

### Owner Mode (your personal version, fully unlocked)
- Identified by `OWNER_EMAILS` server env (source of truth) + `VITE_OWNER_EMAILS` (UI hint)
- Always Opus 4.7 for Claude, always `gemini-2.5-pro` for Gemini, no rate limits, no tier gates, no subscription gate
- Separate `owner-assistant.md` system prompt — Quiet Assassin voice, **unrestricted scope**: code, strategy, medical, legal, financial, anything
- Full client + coach surface visibility
- `/owner` admin panel + `/owner/images` Flux generation lab
- Hidden Owner tile on the home screen for everyone except you

### Phase C — Gemini multimodal (Claude + Gemini both unlocked for owner)
- `gemini-meal-photo` — vision → `{items, total, confidence, notes}`. Powers **Snap a meal** on `/meals`
- `gemini-voice-turn` — audio → `{transcript}`. Powers **mic button** on `/assistant`; transcript pre-fills the input box, you review and send through the existing Claude streaming path
- `gemini-form-check` — short lift video → cue list, locked to PKFIT voice (used by future workout-detail UI)

### Phase D — Apple-style calendar
- Three views: month (6×7 grid), week, day (sectioned agenda)
- Pulls events from 5 tables: workout_sessions, meals, habits.check_history, check_ins, active programs
- **Drag-to-reschedule** on planned lifts — optimistic UPDATE on `workout_sessions.scheduled_for`. Logged sessions are non-draggable (history doesn't move)
- Color-coded chips, native HTML5 DnD, hand-rolled date math, no new deps

### Phase E — Profile intake + encrypted medical + legal consent + Apify import
- Full intake form: legal name, address, DOB, sex, height (ft+in), weight (lb), occupation, training days, equipment, background, goals — American units throughout
- Medical block (conditions, medications, allergies, injuries, emergency contact) AES-256-GCM encrypted at rest with `MEDICAL_ENC_SECRET`. Decrypts only inside Netlify Functions for the authenticated owner of the row
- Three legal pages (`/legal/terms`, `/legal/coaching`, `/legal/privacy`) with V1 markdown content
- Three consent checkboxes block Signup; versions captured in user metadata and persisted to `profiles.consent` by Onboarding
- `/import` page → Apify Trainerize actor → draft program in `/workouts`

### Phase F — fal.ai Image Lab + curated YouTube exercise demos
- `/owner/images` Image Lab: prompt + style override, model picker (Flux schnell/dev/pro), aspect ratio, count 1-4. Cost logged to `fal_usage`
- `exercise_videos` table seeded with 31 universal lifts (Squat University, Athlean-X, Renaissance Periodization, Calisthenicmovement, Bret Contreras)
- Workout generator prompt extended with canonical-name guidance so generated programs match curated demos
- Workouts UI auto-falls-back to library when an exercise has no inline `youtube` field

## Required Netlify env vars (before merge)

```
# Stripe — 3-tier price IDs (legacy ones can stay set for current subscribers)
STRIPE_PRICE_TIER1_MONTHLY / _ANNUAL
STRIPE_PRICE_TIER2_MONTHLY / _ANNUAL
STRIPE_PRICE_TIER3_MONTHLY / _ANNUAL

# Encryption secrets (openssl rand -base64 48)
BYO_KEY_SECRET=...
MEDICAL_ENC_SECRET=...

# AI providers
GEMINI_API_KEY=AIza...
FAL_API_KEY=fal_...

# Apify
APIFY_API_TOKEN=apify_api_...
APIFY_TRAINERIZE_ACTOR_ID=username~trainerize-program-scraper

# Owner mode
OWNER_EMAILS=you@email.com           # server-side enforcement
VITE_OWNER_EMAILS=you@email.com      # client-side UI visibility hint
```

## Migrations to run

```
0027_tier_simplification.sql
0028_calendar_scheduled.sql
0029_profile_intake_legal.sql
0030_exercise_video_library.sql
```

## Test plan

- [x] `npm run lint` — 0 errors
- [x] `npm run build` — clean
- [x] `npm test` — 110/110 pass
- [ ] Stripe test mode: `$250` / `$475` / `$750` checkouts → `profiles.plan` writes correct tier
- [ ] Confirm Assistant streaming uses the matching model per tier
- [ ] Tier 3 BYO: paste `sk-ant-...` via `save-byo-key` → subsequent calls bill the user's Anthropic console
- [ ] Sign in with `OWNER_EMAILS` address → `/home` shows Owner tile → `/owner` panel renders → Image Lab generates an image
- [ ] Verify owner's Assistant uses unrestricted `owner-assistant.md` (ask a non-coaching question, expect a real answer)
- [ ] Snap a meal photo → macros within ±15% → confirm modal → row inserted to `meals`
- [ ] Voice clip in Assistant → transcript pre-fills input box → send through Claude
- [ ] Drag a planned session in Calendar from Tue → Thu → reload → position persists
- [ ] Visit `/legal/terms` etc. → markdown renders cleanly
- [ ] Signup blocks until all three consent boxes are checked → `profiles.consent` populates after onboarding
- [ ] Profile intake form saves; medical block round-trips through `update-profile` + `get-my-medical`
- [ ] `/import` Trainerize URL → draft program lands under `/workouts`
- [ ] Generated program references canonical names → demos auto-resolve from `exercise_videos`

## Post-merge: optional one-shots

- `FAL_API_KEY=fal_... node scripts/generate-trailer.js` to produce the cinematic trailer asset

https://claude.ai/code/session_012KGWyv5ohYSptLopyu3McK