### PR TITLE
Polish: liquid-glass on tag + testimonial, sharper hero typography

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -61,6 +61,37 @@ h1, h2, h3, h4 {
 
 .gold { color: #C8A96E; }
 
+/* ── Liquid glass (sparingly) ── */
+
+.liquid-glass {
+  position: relative;
+  overflow: hidden;
+  background: rgba(255, 255, 255, 0.03);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  box-shadow: inset 0 1px 1px rgba(255, 255, 255, 0.06);
+  border: none;
+}
+
+.liquid-glass::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  border-radius: inherit;
+  padding: 1.4px;
+  background: linear-gradient(180deg,
+    rgba(200, 169, 110, 0.55) 0%,
+    rgba(200, 169, 110, 0.12) 22%,
+    rgba(255, 255, 255, 0) 45%,
+    rgba(255, 255, 255, 0) 55%,
+    rgba(200, 169, 110, 0.12) 78%,
+    rgba(200, 169, 110, 0.55) 100%);
+  -webkit-mask: linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0);
+  -webkit-mask-composite: xor;
+          mask-composite: exclude;
+  pointer-events: none;
+}
+
 /* ── Focus states (A11y) ── */
 
 a:focus-visible,
@@ -112,8 +143,9 @@ section {
 }
 
 .hero h1 {
-  font-size: clamp(3rem, 8vw, 7rem);
-  line-height: 1.05;
+  font-size: clamp(3.25rem, 9vw, 8.5rem);
+  line-height: 1.02;
+  letter-spacing: 0.01em;
   margin-bottom: 24px;
 }
 
@@ -137,12 +169,12 @@ section {
 .hero .tag {
   display: inline-block;
   font-size: 0.75rem;
-  letter-spacing: 0.15em;
+  letter-spacing: 0.18em;
   text-transform: uppercase;
   color: #C8A96E;
-  border: 1px solid rgba(200, 169, 110, 0.3);
-  padding: 6px 16px;
-  margin-bottom: 32px;
+  padding: 8px 18px;
+  border-radius: 999px;
+  margin-bottom: 36px;
 }
 
 /* ── Positioning band ── */
@@ -155,7 +187,7 @@ section {
 
 .positioning p {
   font-family: 'Bebas Neue', sans-serif;
-  font-size: clamp(1.3rem, 3vw, 2rem);
+  font-size: clamp(1.6rem, 4vw, 2.75rem);
   color: #F5F5F5;
   letter-spacing: 0.03em;
   max-width: 780px;
@@ -281,7 +313,7 @@ section {
   max-width: 680px;
   margin: 0 auto;
   padding: 36px 24px;
-  border: 1px solid rgba(200, 169, 110, 0.15);
+  border-radius: 18px;
   position: relative;
 }
 

--- a/blueprint-landing.html
+++ b/blueprint-landing.html
@@ -54,7 +54,7 @@
     <!-- ── Hero ── -->
     <section class="hero">
       <div class="container">
-        <span class="tag">A 30-Day System</span>
+        <span class="tag liquid-glass">A 30-Day System</span>
         <h1>THE PKFIT <br><span class="gold">BLUEPRINT</span></h1>
         <p class="manifesto">The system is the structure. The sequence is the code.</p>
         <p class="subtitle">Stop guessing. Start building. A structured 30-day system that diagnoses your weak points, corrects them, and locks in lasting results.</p>
@@ -150,7 +150,7 @@
     <!-- ── Testimonial ── -->
     <section class="testimonial">
       <div class="container">
-        <div class="testimonial-card">
+        <div class="testimonial-card liquid-glass">
           <img src="/assets/img/copy_1BE065CB-2462-471E-9B96-8704A5802096.png" alt="Dele Bakare transformation — before and after, down 35 lbs" class="testimonial-photo">
           <span class="quote-mark">"</span>
           <blockquote>"I'd never stepped in a gym. Running a business, raising a family — I told myself I didn't have the time. So I made the time. 35 pounds down. Five, six days a week now."</blockquote>


### PR DESCRIPTION
## Summary

Restrained polish pass. Adds the liquid-glass texture as a **rare** detail (two spots only), bumps hero typography to Apple/Nike-level confidence, and gives the positioning band more visual weight.

## What changes

**`assets/css/main.css`**
- New `.liquid-glass` utility — gold-tinted gradient border via `::before` mask, faint white panel, 8px backdrop blur. Built once, reused.
- `.hero h1` — bigger ceiling (`7rem → 8.5rem`), tighter line-height (`1.05 → 1.02`), positive but tight letter-spacing (`0.04em → 0.01em`). Display weight without overdoing it.
- `.hero .tag` — pill shape (`border-radius: 999px`), wider letter-spacing, hard border replaced by liquid-glass.
- `.positioning p` — scaled up (`clamp(1.3rem, 3vw, 2rem) → clamp(1.6rem, 4vw, 2.75rem)`). The line stays declarative, just bigger.
- `.testimonial-card` — hard border replaced by liquid-glass, `border-radius: 18px` added.

**`blueprint-landing.html`**
- Two class additions: `liquid-glass` on `.tag` and `.testimonial-card`. Nothing else.

## What I deliberately didn't touch

- Feature cards (the 6 "What You Get" tiles) — staying flat. Glass on six adjacent cards = noise, not luxury.
- Phase rows (DIAGNOSIS / CORRECTION / IDENTITY SHIFT / THE LOCK) — staying as quiet typographic rows.
- Final CTA, footer, copy, fonts, brand tokens, motion rules — unchanged.
- No video background, no entrance animation, no font swap to Inter. Maturity stands.

## Still pending (from prior threads)

- **OG image redesign** — needs the photo URL or file before I can compose. Nothing in this PR.
- **Orphan Netlify site** `dapper-cupcake-20ea0d` — dashboard delete, your action.

## Test plan

- [ ] Deploy preview hero: tag is a glass pill, H1 sits heavier, the brand line and subtitle still read.
- [ ] Positioning band: bigger but not loud.
- [ ] Testimonial card: glass with subtle gold border highlight, photo and quote unchanged.
- [ ] Feature cards, phase rows, and final CTA visually identical to current production.
- [ ] WCAG AA contrast still passes (no text colors changed).
- [ ] Jekyll CI green, Netlify checks green.


---
_Generated by [Claude Code](https://claude.ai/code/session_019xk5XCfBqAmhyRwAeGmFYA)_