### PR TITLE
Design fixes — top 3 from Apple-tier critique (2026-05-18)

### DIFF
--- a/src/pages/EnterIntro.jsx
+++ b/src/pages/EnterIntro.jsx
@@ -44,7 +44,7 @@ export default function EnterIntro() {
         aria-hidden="true"
         className="transition-opacity duration-100 ease-out hover:opacity-85"
         style={{
-          fontFamily: "'DRUK Wide', 'Druk Wide', 'Bowlby One', sans-serif",
+          fontFamily: "'Bebas Neue', 'DRUK Wide', 'Druk Wide', sans-serif",
           fontWeight: 900,
           fontSize: 'clamp(12rem, 40vw, 32rem)',
           lineHeight: 1,

--- a/src/pages/auth/Signup.jsx
+++ b/src/pages/auth/Signup.jsx
@@ -88,12 +88,12 @@ export default function Signup() {
 
           <fieldset className="space-y-2 border border-line bg-black/30 p-3 text-xs text-mute">
             <legend className="px-1 label">Agreements</legend>
-            <label className="flex items-start gap-2">
+            <label className="flex min-h-[44px] cursor-pointer items-start gap-3 py-2">
               <input
                 type="checkbox"
                 checked={tos}
                 onChange={(e) => setTos(e.target.checked)}
-                className="mt-0.5 accent-gold"
+                className="mt-0.5 h-5 w-5 shrink-0 accent-gold"
                 required
               />
               <span>
@@ -104,12 +104,12 @@ export default function Signup() {
                 .
               </span>
             </label>
-            <label className="flex items-start gap-2">
+            <label className="flex min-h-[44px] cursor-pointer items-start gap-3 py-2">
               <input
                 type="checkbox"
                 checked={coaching}
                 onChange={(e) => setCoaching(e.target.checked)}
-                className="mt-0.5 accent-gold"
+                className="mt-0.5 h-5 w-5 shrink-0 accent-gold"
                 required
               />
               <span>
@@ -120,12 +120,12 @@ export default function Signup() {
                 , including the assumption of risk.
               </span>
             </label>
-            <label className="flex items-start gap-2">
+            <label className="flex min-h-[44px] cursor-pointer items-start gap-3 py-2">
               <input
                 type="checkbox"
                 checked={privacy}
                 onChange={(e) => setPrivacy(e.target.checked)}
-                className="mt-0.5 accent-gold"
+                className="mt-0.5 h-5 w-5 shrink-0 accent-gold"
                 required
               />
               <span>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -12,8 +12,10 @@ export default {
         ink: '#F5F5F5',
         mute: '#BFBFBF',
         faint: '#9A9A9A',
-        // minimalist 2026-05-01: line tint moved off yellow rgba onto neutral cream.
-        line: 'rgba(245, 241, 232, 0.12)',
+        // WCAG 1.4.11 fix: alpha 0.12 resolved to ~1.3:1 over the #080808
+        // page — borders read as voids. Bumped to 0.40 → ~3.45:1, clearing
+        // the 3:1 minimum for non-text UI boundaries with a small margin.
+        line: 'rgba(245, 241, 232, 0.40)',
         signal: '#A03A2C',
         success: '#7A8C5C',
       },

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -18,10 +18,11 @@ export default {
         success: '#7A8C5C',
       },
       fontFamily: {
-        // block 0 2026-05-05: PK•FIT brand cascade. DRUK Wide is the target;
-        // Druk Wide and Bowlby One are restrained fallbacks for when the
-        // licensed face is not yet bundled. system-ui closes the chain.
-        display: ['"DRUK Wide"', '"Druk Wide"', '"Bowlby One"', 'system-ui', 'sans-serif'],
+        // PK•FIT brand cascade. Bebas Neue is bundled and self-hosted from
+        // /public/fonts/. DRUK Wide is reserved as a future-licensed face;
+        // it stays in the chain so the day the woff2 is added the brand can
+        // upgrade without touching component code. system-ui closes the chain.
+        display: ['"Bebas Neue"', '"DRUK Wide"', '"Druk Wide"', 'system-ui', 'sans-serif'],
         body: ['"DM Mono"', 'ui-monospace', 'monospace'],
       },
       letterSpacing: {


### PR DESCRIPTION
## Summary

Surgical fixes for the three highest-leverage issues from the Apple-tier critique at `~/Documents/PKFIT/Operations/operatefitness-design-critique-2026-05-18.md`. Three commits, three files touched, ~16 lines of net change.

### What ships

1. **Brand font catastrophe → fixed.** (`tailwind.config.js`, `src/pages/EnterIntro.jsx`)
   - The `font-display` chain previously declared `DRUK Wide` / `Druk Wide` / `Bowlby One` — none of which are bundled (no `@font-face`). Every heading on every page fell through to the OS system font (San Francisco on iOS, Roboto on Android). Bebas Neue **was** bundled at `/public/fonts/bebas-neue-v16-latin-400.woff2` but sat unreferenced.
   - **Now:** `font-display` cascade is `['"Bebas Neue"', '"DRUK Wide"', '"Druk Wide"', 'system-ui', 'sans-serif']`. The bundled face is now the resolved one across every `font-display` utility — homepage "P", H1s, hero typography, buttons, all of it.
   - The inline `fontFamily` on the EnterIntro "P" was also updated to put Bebas Neue first (it has its own inline style and does not use the Tailwind cascade).
   - DRUK Wide is kept in the chain as a future-licensed-face hook — when/if Percy licenses the woff2 from Commercial Type, drop it into `/public/fonts/`, add the `@font-face`, and the upgrade is automatic. No component code changes needed.

2. **Signup checkbox tap targets → 44×44 Apple HIG compliant.** (`src/pages/auth/Signup.jsx`)
   - The three consent checkboxes were the browser-default 13×13 px inside a 16 px label row — roughly 30% of the Apple HIG minimum.
   - **Now:** each checkbox is `h-5 w-5` (20 px visible) with `shrink-0` so long wrapping text can't squash the box. Each surrounding label row gets `min-h-[44px]` + `py-2` + `cursor-pointer` + `gap-3`. Effective tap zone clears 44 pt vertically and the entire row width horizontally. `accent-gold` retained — the checked state still picks up the cream/gold token.
   - Visual balance preserved: `items-start` + `mt-0.5` keeps the box aligned with the first text line.

3. **Input border contrast → WCAG 1.4.11 cleared.** (`tailwind.config.js`)
   - The `line` token was `rgba(245, 241, 232, 0.12)` — composites to ~1.3:1 against `#080808`. WCAG 1.4.11 requires 3:1 for non-text UI boundaries.
   - **Now:** `rgba(245, 241, 232, 0.40)` — composites to ~3.45:1 (cleared with a small margin). Contrast math: the critique estimated 0.30 would clear 3:1; in practice 0.30 only gets to ~2.4:1, so the call here was 0.40 to clear it with margin.
   - Single source: the `line` token in `tailwind.config.js`. Every `border-line` utility across the app picks it up — inputs, textareas, selects, the signup fieldset, cards, modals, all of it.
   - Focus state (solid `border-gold`) is unchanged.

### Lint / build

- `npm run build` → clean ✓
- `npm run lint` → **same 2 pre-existing errors as `app-main`** (unrelated to this change): unescaped `'` in `src/pages/coach/AssistantLog.jsx:117` and an unused `Card` import in `src/pages/coach/Dashboard.jsx:6`. Verified by stashing my changes and running lint on baseline — same 2/31. **Not touched per the don't-touch-pre-existing-failures rule.**

### Calls made (decision log)

- **Fix 1:** kept DRUK in the cascade after Bebas rather than removing it entirely. Lets us upgrade later by adding one `@font-face` block, no component churn. Per critique recommendation §3.2 Path A.
- **Fix 2:** went with 20 px visible (h-5 w-5) over 24 px to keep the consent block visually restrained — 20 px is at the lower end of the user's "20-24px" range but still ~50% larger than the original. Could revisit if Percy wants beefier.
- **Fix 3:** went with 0.40 alpha instead of the critique's suggested 0.28-0.32 because the lower band only clears ~2.4:1, which still fails 1.4.11. 0.40 gives ~3.45:1 with margin while remaining subtle.

### What Percy will see different at operatefitness.app once Netlify deploys

- The homepage "P", every H1 ("Welcome back", "Create account"), every button label, and every heading across the app now renders in **Bebas Neue** instead of the OS system font. Visible everywhere — single biggest brand presence change in one PR.
- Signup checkbox boxes ~50% larger and the whole row tappable. No more thumb-hunting.
- Inputs, textareas, selects, fieldsets, cards — every chrome border is visibly there now instead of reading as voids.

### Out of scope (left for future PRs from the critique's prioritized fix list)

Items 4-10 (link underlines, `<main>` landmark on `/`, microcopy under "P", legal body font swap, og:image absolute, Permissions-Policy header, disabled button ghost state) are all in the critique but not in this PR's scope. Each is a separate small change.

## Test plan

- [ ] Open `/` on a real device — confirm the "P" is Bebas Neue (slab condensed caps), not San Francisco
- [ ] Open `/login` — confirm "Welcome back" H1 is Bebas Neue
- [ ] Open `/signup` — confirm "Create account" H1 is Bebas Neue
- [ ] On `/signup`, confirm the three consent rows are obviously tappable (44 pt+ height)
- [ ] On `/signup`, confirm all input borders are clearly visible against the background
- [ ] Across the app, sanity-check that no heading suddenly looks oversized — Bebas is taller than the OS sans-serif fallback was rendering at the same `text-size` utility, so visual rhythm may shift very slightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)