### PR TITLE
Phase 2A — The Standard Audit foundation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,19 @@ STRIPE_PRICE_FULL_ANNUAL=price_xxx
 STRIPE_PRICE_PREMIUM_MONTHLY=price_xxx
 STRIPE_PRICE_PREMIUM_ANNUAL=price_xxx
 
+# ─── THE STANDARD AUDIT (Phase 2A — audit.pkfit.com funnel) ───────────────
+# Separate webhook endpoint signing secret for the $47 Standard Audit
+# Stripe Product. Distinct from STRIPE_WEBHOOK_SECRET so the audit funnel
+# can be rotated independently of the coaching subscription webhook.
+STRIPE_AUDIT_WEBHOOK_SECRET=whsec_xxx
+# Stripe Price ID for The Standard Audit ($47 one-time). Set after running
+# the Stripe product-creation script (see PHASE-2A-NOTES.md).
+STRIPE_PRICE_STANDARD_AUDIT=price_xxx
+# Stripe Product ID (logged for audit trail; not used at runtime).
+STRIPE_PRODUCT_STANDARD_AUDIT=prod_xxx
+# Audit subdomain — set to https://audit.pkfit.com once Phase 2D registers DNS.
+AUDIT_SITE_URL=https://audit.pkfit.com
+
 # ─── BYO ANTHROPIC KEY (tier3 subscribers) ────────────────────────────────
 # 32+ char random secret used to AES-256-GCM encrypt tier3 subscribers'
 # pasted Anthropic API keys at rest. Generate with: openssl rand -base64 48

--- a/netlify.toml
+++ b/netlify.toml
@@ -49,6 +49,14 @@
   schedule = "0 14 * * *"
 
 [[redirects]]
+  # Phase 2A: clean alias for The Standard Audit webhook so audit.pkfit.com
+  # and downstream Stripe configuration can point at /api/webhooks/stripe-audit.
+  from = "/api/webhooks/stripe-audit"
+  to = "/.netlify/functions/stripe-audit-webhook"
+  status = 200
+  force = true
+
+[[redirects]]
   from = "/*"
   to = "/index.html"
   status = 200

--- a/netlify/functions/stripe-audit-webhook.js
+++ b/netlify/functions/stripe-audit-webhook.js
@@ -1,0 +1,180 @@
+// stripe-audit-webhook.js
+// Endpoint: /.netlify/functions/stripe-audit-webhook (also exposed at
+// /api/webhooks/stripe-audit via netlify.toml redirect).
+//
+// Phase 2A scope: verify signature, insert audit row + log event. Magic-link
+// generation + Kit tagging + transactional email all land in Phase 2B.
+// This is intentionally a foundation stub — the surface and idempotency
+// guarantees are wired so Phase 2B can extend without touching plumbing.
+//
+// Architecture reference: ~/Documents/PKFIT/Funnel/ARCHITECTURE.md §2.7
+
+import { jsonResponse } from './_shared/auth.js';
+import { getAdminClient } from './_shared/supabase-admin.js';
+import { getStripe } from './_shared/stripe.js';
+import crypto from 'node:crypto';
+
+const AUDIT_WEBHOOK_SECRET_ENV = 'STRIPE_AUDIT_WEBHOOK_SECRET';
+const AUDIT_PRICE_ENV = 'STRIPE_PRICE_STANDARD_AUDIT';
+
+function issueMagicLinkToken() {
+  return crypto.randomBytes(32).toString('base64url');
+}
+
+export const handler = async (event) => {
+  if (event.httpMethod !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  const sig = event.headers?.['stripe-signature'] || event.headers?.['Stripe-Signature'];
+  if (!sig) return jsonResponse(400, { error: 'Missing Stripe-Signature header' });
+
+  const secret = process.env[AUDIT_WEBHOOK_SECRET_ENV];
+  if (!secret) {
+    console.error(`${AUDIT_WEBHOOK_SECRET_ENV} is not configured`);
+    return jsonResponse(500, { error: 'Webhook secret not configured' });
+  }
+
+  const stripe = getStripe();
+  const raw = event.isBase64Encoded
+    ? Buffer.from(event.body, 'base64').toString('utf8')
+    : event.body;
+
+  let stripeEvent;
+  try {
+    stripeEvent = stripe.webhooks.constructEvent(raw, sig, secret);
+  } catch (err) {
+    return jsonResponse(400, { error: `Webhook verification failed: ${err.message}` });
+  }
+
+  const admin = getAdminClient();
+
+  // Idempotency via the existing stripe_events table (migration 0014).
+  const { error: dedupErr } = await admin
+    .from('stripe_events')
+    .insert({ stripe_event_id: stripeEvent.id, type: stripeEvent.type });
+  if (dedupErr?.code === '23505') {
+    return jsonResponse(200, { received: true, duplicate: true });
+  }
+  if (dedupErr) {
+    return jsonResponse(500, { error: dedupErr.message });
+  }
+
+  try {
+    switch (stripeEvent.type) {
+      case 'checkout.session.completed': {
+        const session = stripeEvent.data.object;
+
+        // Guard: only handle sessions tied to the audit price.
+        const expectedPrice = process.env[AUDIT_PRICE_ENV];
+        const lineItemPrice = session.metadata?.price_id
+          || session.metadata?.product_code;
+        if (expectedPrice && lineItemPrice && lineItemPrice !== expectedPrice
+            && session.metadata?.product_code !== 'default_paralysis_diagnostic') {
+          // Different product flowed through the same endpoint by mistake.
+          // Acknowledge and move on so Stripe stops retrying.
+          return jsonResponse(200, { received: true, skipped: 'wrong_product' });
+        }
+
+        const email = session.customer_email
+          || session.customer_details?.email
+          || session.metadata?.email
+          || null;
+        if (!email) {
+          console.error('audit webhook: checkout.session.completed missing email', session.id);
+          return jsonResponse(200, { received: true, skipped: 'no_email' });
+        }
+
+        const firstName = session.custom_fields?.find?.(
+          (f) => f.key === 'first_name',
+        )?.text?.value
+          || session.metadata?.first_name
+          || null;
+
+        const partneredRaw = session.custom_fields?.find?.(
+          (f) => f.key === 'partnered',
+        )?.dropdown?.value;
+        const partnered = partneredRaw === 'yes' ? true
+          : partneredRaw === 'no' ? false
+          : null;
+
+        const magicLinkToken = issueMagicLinkToken();
+        const magicLinkExpires = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+        const { error: insertErr } = await admin.from('audits').insert({
+          email,
+          stripe_id: session.id,
+          magic_link_token: magicLinkToken,
+          magic_link_expires: magicLinkExpires,
+          status: 'purchased',
+          first_name: firstName,
+          partnered,
+        });
+        if (insertErr && insertErr.code !== '23505') {
+          console.error('audit insert failed', insertErr);
+          return jsonResponse(500, { error: insertErr.message });
+        }
+
+        // Lead mirror: upsert into leads with audit_purchased tag.
+        await admin.from('leads').upsert(
+          {
+            email,
+            first_name: firstName,
+            partnered,
+            source: session.metadata?.source ?? 'diagnostic_landing',
+            status: 'audit_purchased',
+            tags: ['audit_purchased'],
+            last_active: new Date().toISOString(),
+          },
+          { onConflict: 'email' },
+        );
+
+        // Event log.
+        await admin.from('events').insert({
+          name: 'audit_purchased',
+          subject_id: email,
+          email,
+          properties: {
+            stripe_session_id: session.id,
+            amount_total: session.amount_total,
+            first_name: firstName,
+            partnered,
+          },
+          funnel_layer: 3,
+          source: 'stripe',
+        });
+
+        // Phase 2B will: trigger Kit tag `audit_purchased`, send the magic
+        // link via Kit broadcast, and surface `magic_link_token` in the
+        // welcome email. For now the token is persisted; the buyer journey
+        // resumes once Phase 2B lands the messaging layer.
+        return jsonResponse(200, {
+          received: true,
+          audit_id_persisted: true,
+          phase: '2A',
+        });
+      }
+      case 'checkout.session.expired':
+      case 'checkout.session.async_payment_failed': {
+        const session = stripeEvent.data.object;
+        await admin.from('events').insert({
+          name: 'audit_checkout_failed',
+          subject_id: session.customer_email ?? null,
+          email: session.customer_email ?? null,
+          properties: {
+            stripe_session_id: session.id,
+            reason: stripeEvent.type,
+          },
+          funnel_layer: 3,
+          source: 'stripe',
+        });
+        return jsonResponse(200, { received: true });
+      }
+      default:
+        return jsonResponse(200, { received: true, ignored: stripeEvent.type });
+    }
+  } catch (err) {
+    console.error('stripe-audit-webhook handler error', err);
+    return jsonResponse(500, { error: err.message ?? 'internal_error' });
+  }
+};

--- a/scripts/stripe-audit-product.mjs
+++ b/scripts/stripe-audit-product.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+/**
+ * stripe-audit-product.mjs
+ *
+ * Creates "The Standard Audit" Stripe Product + $47 one-time Price in TEST
+ * MODE. Idempotent — re-running with the same product_code metadata updates
+ * the existing product instead of creating a duplicate.
+ *
+ * Run from pkfit-architect root:
+ *
+ *   STRIPE_API_KEY=sk_test_xxx node scripts/stripe-audit-product.mjs
+ *
+ * To force live mode (Phase 3 only, after QA sign-off), set STRIPE_LIVE=1
+ * AND pass a sk_live_ key. The script refuses to run with a live key
+ * unless STRIPE_LIVE=1 is explicit.
+ *
+ * Output: prints product_id, price_id, statement_descriptor. Append these
+ * to your Netlify env as STRIPE_PRODUCT_STANDARD_AUDIT / STRIPE_PRICE_STANDARD_AUDIT.
+ */
+
+import Stripe from 'stripe';
+
+const key = process.env.STRIPE_API_KEY;
+if (!key) {
+  console.error('STRIPE_API_KEY env var is required (sk_test_xxx for test mode).');
+  process.exit(1);
+}
+
+if (key.startsWith('sk_live_') && process.env.STRIPE_LIVE !== '1') {
+  console.error(
+    'Refusing to run against a LIVE key without STRIPE_LIVE=1. ' +
+      'Phase 2A is test-mode-only; live mode is gated behind Phase 3 QA.',
+  );
+  process.exit(1);
+}
+
+const stripe = new Stripe(key, { apiVersion: '2025-02-24.acacia' });
+
+const PRODUCT_CODE = 'default_paralysis_diagnostic';
+
+async function findExistingProduct() {
+  // Stripe doesn't index custom metadata for search on standard accounts;
+  // page through products and match by metadata.product_code.
+  let result = await stripe.products.list({ limit: 100, active: true });
+  for (;;) {
+    const match = result.data.find(
+      (p) => p.metadata?.product_code === PRODUCT_CODE,
+    );
+    if (match) return match;
+    if (!result.has_more) return null;
+    const last = result.data[result.data.length - 1];
+    result = await stripe.products.list({ limit: 100, starting_after: last.id });
+  }
+}
+
+async function findActiveOneTime47Price(productId) {
+  const prices = await stripe.prices.list({
+    product: productId,
+    active: true,
+    limit: 100,
+  });
+  return (
+    prices.data.find(
+      (p) =>
+        p.unit_amount === 4700 &&
+        p.currency === 'usd' &&
+        p.type === 'one_time',
+    ) ?? null
+  );
+}
+
+(async () => {
+  console.log(
+    `Stripe mode: ${key.startsWith('sk_live_') ? 'LIVE' : 'TEST'}`,
+  );
+
+  let product = await findExistingProduct();
+  if (product) {
+    console.log(`Found existing product: ${product.id}. Updating...`);
+    product = await stripe.products.update(product.id, {
+      name: 'The Standard Audit',
+      description:
+        'Diagnose the mechanism behind the breakdown. $47 includes the diagnostic, a written verdict, and a 14-day protocol.',
+      statement_descriptor: 'PKFIT AUDIT',
+      metadata: {
+        product_code: PRODUCT_CODE,
+        funnel_layer: '3',
+        upsell_target: 'performance_standard',
+      },
+    });
+  } else {
+    console.log('No existing product. Creating...');
+    product = await stripe.products.create({
+      name: 'The Standard Audit',
+      description:
+        'Diagnose the mechanism behind the breakdown. $47 includes the diagnostic, a written verdict, and a 14-day protocol.',
+      statement_descriptor: 'PKFIT AUDIT',
+      metadata: {
+        product_code: PRODUCT_CODE,
+        funnel_layer: '3',
+        upsell_target: 'performance_standard',
+      },
+    });
+  }
+
+  let price = await findActiveOneTime47Price(product.id);
+  if (!price) {
+    console.log('Creating $47 one-time price...');
+    price = await stripe.prices.create({
+      product: product.id,
+      unit_amount: 4700,
+      currency: 'usd',
+      metadata: { product_code: PRODUCT_CODE },
+    });
+  } else {
+    console.log(`Found existing $47 price: ${price.id}`);
+  }
+
+  console.log('');
+  console.log('─── Phase 2A Stripe Setup ──────────────────────────────');
+  console.log(`Product ID:           ${product.id}`);
+  console.log(`Price ID:             ${price.id}`);
+  console.log(`Statement descriptor: ${product.statement_descriptor}`);
+  console.log(`Mode:                 ${key.startsWith('sk_live_') ? 'LIVE' : 'TEST'}`);
+  console.log('');
+  console.log('Add to Netlify env (pkfit-architect):');
+  console.log(`  STRIPE_PRODUCT_STANDARD_AUDIT=${product.id}`);
+  console.log(`  STRIPE_PRICE_STANDARD_AUDIT=${price.id}`);
+  console.log('');
+  console.log('Next: create webhook endpoint in Stripe dashboard pointing at');
+  console.log('  https://<netlify-site>/api/webhooks/stripe-audit');
+  console.log('Capture the resulting whsec_xxx and set STRIPE_AUDIT_WEBHOOK_SECRET.');
+})().catch((err) => {
+  console.error('stripe-audit-product failed:', err.message ?? err);
+  process.exit(1);
+});

--- a/supabase/migrations/20260520120000_0053_audit_funnel_tables.sql
+++ b/supabase/migrations/20260520120000_0053_audit_funnel_tables.sql
@@ -1,0 +1,99 @@
+-- 0053_audit_funnel_tables.sql
+-- Phase 2A foundation for The Standard Audit funnel (audit.pkfit.com).
+-- Three tables, server-side writes only, anon reads disabled.
+-- Reference: ~/Documents/PKFIT/Funnel/ARCHITECTURE.md sections 2.7 and 5.
+
+-- ─── audits ──────────────────────────────────────────────────────────────
+-- One row per Stripe checkout for The Standard Audit. Magic-link token is
+-- the bearer credential the buyer uses to open audit.pkfit.com/take/[token].
+-- output_verdict holds the rendered output JSON so re-views are deterministic.
+
+create table if not exists public.audits (
+  id                  uuid primary key default gen_random_uuid(),
+  email               text not null,
+  stripe_id           text unique,                  -- checkout session id
+  magic_link_token    text unique,                  -- bearer token, 64+ chars
+  magic_link_expires  timestamptz,                  -- 24h TTL on issuance
+  status              text not null default 'purchased',
+                                                    -- purchased|started|completed|abandoned
+  signature           text,                         -- e.g. "M02-avoid-spouse-morning"
+  m02_result          jsonb,
+  m03_result          jsonb,
+  q9_marriage_answer  text,                         -- raw Q9 text for verdict readback
+  output_verdict      jsonb,                        -- full rendered output template
+  first_name          text,
+  partnered           boolean,
+  created_at          timestamptz not null default now(),
+  started_at          timestamptz,
+  completed_at        timestamptz,
+  constraint audits_status_check
+    check (status in ('purchased', 'started', 'completed', 'abandoned'))
+);
+
+create index if not exists audits_email_idx       on public.audits (email);
+create index if not exists audits_created_at_idx  on public.audits (created_at desc);
+create index if not exists audits_stripe_id_idx   on public.audits (stripe_id);
+create index if not exists audits_status_idx      on public.audits (status);
+
+alter table public.audits enable row level security;
+-- No client-facing policies. The audit app reads/writes via service role only.
+-- The buyer authenticates by magic_link_token at the application layer.
+
+-- ─── events ──────────────────────────────────────────────────────────────
+-- Funnel-wide event log per architecture Section 5.1. Subject is email or
+-- anonymous id. funnel_layer is 0..5 mapped to the architecture diagram.
+
+create table if not exists public.events (
+  id            uuid primary key default gen_random_uuid(),
+  created_at    timestamptz not null default now(),
+  name          text not null,                     -- e.g. audit_purchased, audit_completed
+  subject_id    text,                              -- email or anon id
+  email         text,                              -- denormalized for fast lookups
+  subscriber_id text,                              -- Kit subscriber id when known
+  properties    jsonb not null default '{}'::jsonb,
+  funnel_layer  smallint,                          -- 0..5
+  source        text                               -- stripe|app|kit|manychat|landing
+);
+
+create index if not exists events_created_at_idx on public.events (created_at desc);
+create index if not exists events_name_idx       on public.events (name);
+create index if not exists events_email_idx      on public.events (email);
+create index if not exists events_layer_idx      on public.events (funnel_layer);
+
+alter table public.events enable row level security;
+-- No client-facing policies. Server-side writes only.
+
+-- ─── leads ───────────────────────────────────────────────────────────────
+-- Lightweight CRM mirror. Kit is the messaging layer; this is the durable
+-- record of who entered the funnel and where they sit. tags is a flat array
+-- mirroring the Kit tag taxonomy (architecture Section 4.2).
+
+create table if not exists public.leads (
+  id            uuid primary key default gen_random_uuid(),
+  email         text not null unique,
+  first_name    text,
+  partnered     boolean,
+  source        text,                              -- landing|dm|podcast|referral
+  tags          text[] not null default '{}',
+  status        text not null default 'warm',
+                                                    -- warm|audit_purchased|audit_completed|client|churned
+  first_seen    timestamptz not null default now(),
+  last_active   timestamptz not null default now(),
+  constraint leads_status_check
+    check (status in ('warm', 'audit_purchased', 'audit_completed', 'client', 'churned'))
+);
+
+create index if not exists leads_email_idx        on public.leads (email);
+create index if not exists leads_status_idx       on public.leads (status);
+create index if not exists leads_last_active_idx  on public.leads (last_active desc);
+create index if not exists leads_tags_idx         on public.leads using gin (tags);
+
+alter table public.leads enable row level security;
+-- No client-facing policies. Server-side writes only.
+
+comment on table public.audits is
+  'The Standard Audit purchase + diagnostic state. Service-role writes only.';
+comment on table public.events is
+  'Funnel-wide event log. Subject is email or anon id. Service-role writes only.';
+comment on table public.leads is
+  'CRM mirror of Kit subscribers. Tags mirror Kit taxonomy. Service-role writes only.';


### PR DESCRIPTION
## Summary

Phase 2A of the PKFIT funnel rebuild — the data + payment foundation for `audit.pkfit.com`. Architecture reference: `~/Documents/PKFIT/Funnel/ARCHITECTURE.md`.

- Supabase migration `0053`: `audits` / `events` / `leads` tables, server-write-only RLS, indexed per architecture §5.
- Netlify function `stripe-audit-webhook`: signature-verify, persist audit row + 24h magic-link token, upsert lead, log event. Phase 2B adds Kit tag + transactional email.
- `netlify.toml` redirect: `/api/webhooks/stripe-audit` → function.
- `scripts/stripe-audit-product.mjs`: idempotent test-mode Stripe product/price creation; refuses live keys unless `STRIPE_LIVE=1`.
- `.env.example`: four new audit-funnel env vars documented (`STRIPE_AUDIT_WEBHOOK_SECRET`, `STRIPE_PRICE_STANDARD_AUDIT`, `STRIPE_PRODUCT_STANDARD_AUDIT`, `AUDIT_SITE_URL`).

No existing prod paths modified. Coaching app at operatefitness.app stays untouched.

The sibling pkfit-audit Next.js repo (Phase 2A scaffold) lives at `~/dev/pkfit-audit/` on branch `phase-2a-foundation` — separate repo, not part of this PR.

## Test plan

- [ ] Apply migration 0053 to Supabase (via `supabase db push` or dashboard SQL editor)
- [ ] Run `STRIPE_API_KEY=sk_test_xxx node scripts/stripe-audit-product.mjs` from repo root to create test-mode product + $47 price
- [ ] In Stripe dashboard (test mode) → Webhooks → add endpoint pointing at `https://<netlify-site>/api/webhooks/stripe-audit` for `checkout.session.{completed,expired,async_payment_failed}`
- [ ] Set `STRIPE_AUDIT_WEBHOOK_SECRET` + `STRIPE_PRICE_STANDARD_AUDIT` + `STRIPE_PRODUCT_STANDARD_AUDIT` in Netlify env
- [ ] Send a Stripe test webhook event; confirm 200 in Netlify function logs and one new row in `events` table

Phase 2A notes: `~/Documents/PKFIT/Funnel/PHASE-2A-NOTES.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)