### PR TITLE
Fix: /api/webhooks/stripe-audit redirect shadowed by _redirects

### DIFF
--- a/public/_redirects
+++ b/public/_redirects
@@ -1,1 +1,5 @@
+# Stripe webhook alias for The Standard Audit. Must precede the SPA fallback —
+# _redirects takes precedence over netlify.toml, and first-match wins.
+/api/webhooks/stripe-audit  /.netlify/functions/stripe-audit-webhook  200!
+
 /*  /index.html  200


### PR DESCRIPTION
Follow-up to #42. The netlify.toml redirect for the audit webhook alias was being shadowed by \`public/_redirects\` (Netlify gives \`_redirects\` precedence). Verified post-#42:

- \`POST /.netlify/functions/stripe-audit-webhook\` → \`400 {"error":"Missing Stripe-Signature header"}\` ✓ (handler live)
- \`POST /api/webhooks/stripe-audit\` → \`404 SPA fallback\` ✗ (alias broken)

This adds the alias to \`_redirects\` before the SPA catch-all. Using \`200!\` to force the rewrite past any method-based shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)