### PR TITLE
feat(activation): magic-link invite + auto-assign coach + starter programs

### DIFF
--- a/netlify/functions/_prompts/invite-client.txt
+++ b/netlify/functions/_prompts/invite-client.txt
@@ -1,0 +1,15 @@
+SUBJECT: Your PKFIT app is ready
+
+---
+
+{{first_name}},
+
+I built you an account on the PKFIT coaching app. Programming, check-ins, the AI assistant — all in one place.
+
+Sign in with the link below. It opens straight to your home screen. No password to remember.
+
+{{magic_url}}
+
+The link is good for 24 hours. If it expires, reply and I'll send a fresh one.
+
+— Percy

--- a/netlify/functions/invite-client.js
+++ b/netlify/functions/invite-client.js
@@ -1,0 +1,170 @@
+// invite-client
+//
+// Sends a magic-link onboarding email to a new client. Called from the
+// coach roster page when Percy adds someone (and from any future bulk
+// admin tool). The function:
+//
+//   1. Auth-gates to coach/owner roles via requireUser.
+//   2. Looks up the auth.users row by email; creates it (email_confirm=true,
+//      so no Supabase confirmation noise) when missing. The handle_new_user
+//      trigger on auth.users (0001) + activate_new_client trigger on
+//      profiles (0053) bind the coach + clone the starter programs.
+//   3. Generates a magic-link via the admin API. We don't use Supabase's
+//      built-in invite mailer because the sender domain and copy need to be
+//      PKFIT's, not the default Supabase template.
+//   4. Sends the email via Resend from coach@operatefitness.app, with
+//      reply-to set to Percy's inbox so client replies land somewhere a
+//      human reads.
+//
+// Env required:
+//   SUPABASE_SERVICE_ROLE_KEY
+//   VITE_SUPABASE_URL (or SUPABASE_URL)
+//   RESEND_API_KEY                     (verified for operatefitness.app)
+//   VITE_SITE_URL                      (e.g. https://app.pkfit.app)
+//   INVITE_FROM_EMAIL                  default: coach@operatefitness.app
+//   INVITE_REPLY_TO                    default: percyhendrux123@gmail.com
+
+import { requireUser, jsonResponse, errorResponse } from './_shared/auth.js';
+import { getAdminClient } from './_shared/supabase-admin.js';
+import { loadPrompt } from './_shared/anthropic.js';
+
+const DEFAULT_FROM = 'coach@operatefitness.app';
+const DEFAULT_REPLY_TO = 'percyhendrux123@gmail.com';
+const FROM_NAME = 'Percy';
+
+export const handler = async (event) => {
+  try {
+    if (event.httpMethod !== 'POST') {
+      return jsonResponse(405, { error: 'Method not allowed' });
+    }
+
+    const { role } = await requireUser(event);
+    if (role !== 'coach' && role !== 'owner') {
+      return jsonResponse(403, { error: 'Coach or owner only' });
+    }
+
+    const payload = safeJson(event.body);
+    const email = String(payload?.email ?? '').trim().toLowerCase();
+    const name = String(payload?.name ?? '').trim();
+    if (!email || !email.includes('@')) {
+      return jsonResponse(400, { error: 'Valid email required' });
+    }
+
+    const admin = getAdminClient();
+
+    // 1. Ensure an auth.users row exists. createUser returns an error when
+    //    the email is already taken — we treat that as "already exists" and
+    //    fall through to magic-link generation. Any other failure bubbles up.
+    let createdUserId = null;
+    {
+      const { data, error } = await admin.auth.admin.createUser({
+        email,
+        email_confirm: true,
+        user_metadata: name ? { name } : {},
+      });
+      if (error) {
+        const msg = String(error.message ?? '').toLowerCase();
+        const alreadyExists =
+          msg.includes('already') || msg.includes('exists') || msg.includes('registered');
+        if (!alreadyExists) throw error;
+      } else {
+        createdUserId = data?.user?.id ?? null;
+      }
+    }
+
+    // 2. Generate a magic link. redirectTo lands the client on /home,
+    //    which is gated by ProtectedRoute + RequiresActiveSubscription.
+    //    The subscription gate is the next blocker but is out of P0 scope.
+    const siteUrl = process.env.VITE_SITE_URL || 'https://app.pkfit.app';
+    const { data: linkData, error: linkErr } = await admin.auth.admin.generateLink({
+      type: 'magiclink',
+      email,
+      options: { redirectTo: `${siteUrl}/home` },
+    });
+    if (linkErr) throw linkErr;
+    const magicUrl = linkData?.properties?.action_link ?? linkData?.action_link ?? null;
+    if (!magicUrl) throw new Error('Failed to generate magic link');
+
+    // 3. Render + send the email.
+    const firstName = name ? name.split(' ')[0] : email.split('@')[0];
+    const { subject, body } = renderInvite({ firstName, magicUrl });
+    const send = await sendInviteEmail({ to: email, subject, body });
+
+    if (!send.sent) {
+      // RESEND_API_KEY unset on the env. Surface the magic_url so Percy
+      // can still hand it off out-of-band rather than silently failing.
+      return jsonResponse(500, {
+        error: 'Email transport not configured (RESEND_API_KEY missing)',
+        magic_url: magicUrl,
+      });
+    }
+
+    return jsonResponse(200, {
+      ok: true,
+      email,
+      auth_user_id: createdUserId,
+      email_id: send.id ?? null,
+    });
+  } catch (e) {
+    return errorResponse(e);
+  }
+};
+
+function safeJson(s) {
+  if (!s) return {};
+  try {
+    return JSON.parse(s);
+  } catch {
+    return {};
+  }
+}
+
+export function renderInvite({ firstName, magicUrl }) {
+  const raw = loadPrompt('invite-client.txt');
+  const lines = raw.split('\n');
+  const subjectLine = lines.find((l) => l.startsWith('SUBJECT:'));
+  const subject = (subjectLine ?? 'SUBJECT: Your PKFIT app is ready')
+    .slice('SUBJECT:'.length)
+    .trim();
+  const dividerIdx = lines.findIndex((l) => l.trim() === '---');
+  const bodyRaw = dividerIdx >= 0 ? lines.slice(dividerIdx + 1).join('\n') : raw;
+  const body = bodyRaw
+    .replace(/\{\{\s*first_name\s*\}\}/g, firstName)
+    .replace(/\{\{\s*magic_url\s*\}\}/g, magicUrl)
+    .replace(/^\n+/, '');
+  return { subject, body };
+}
+
+async function sendInviteEmail({ to, subject, body }) {
+  const apiKey = process.env.RESEND_API_KEY;
+  const from = process.env.INVITE_FROM_EMAIL || DEFAULT_FROM;
+  const replyTo = process.env.INVITE_REPLY_TO || DEFAULT_REPLY_TO;
+
+  if (!apiKey) {
+    // eslint-disable-next-line no-console
+    console.warn(`[invite-client] RESEND_API_KEY unset — would send "${subject}" to ${to}`);
+    return { sent: false, reason: 'no_provider' };
+  }
+
+  const res = await fetch('https://api.resend.com/emails', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      from: `${FROM_NAME} <${from}>`,
+      to: [to],
+      reply_to: replyTo,
+      subject,
+      text: body,
+    }),
+  });
+
+  if (!res.ok) {
+    const errBody = await res.text();
+    throw new Error(`Resend ${res.status}: ${errBody.slice(0, 200)}`);
+  }
+  const json = await res.json();
+  return { sent: true, id: json?.id ?? null };
+}

--- a/src/pages/coach/Clients.jsx
+++ b/src/pages/coach/Clients.jsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { supabase, isSupabaseConfigured } from '../../lib/supabaseClient';
-import { Download } from 'lucide-react';
+import { Download, Mail } from 'lucide-react';
 import { Input, Select } from '../../components/ui/Input';
 import { Badge } from '../../components/ui/Badge';
 import { Button } from '../../components/ui/Button';
@@ -9,6 +9,76 @@ import { Avatar } from '../../components/ui/Avatar';
 import { Empty, Spinner } from '../../components/ui/Empty';
 import { deriveLoopStage, loopStageMeta } from '../../lib/loop';
 import { downloadCSV } from '../../lib/csv';
+
+async function callInviteClient({ email, name }) {
+  const { data: { session } } = await supabase.auth.getSession();
+  const res = await fetch('/.netlify/functions/invite-client', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${session?.access_token ?? ''}`,
+    },
+    body: JSON.stringify({ email, name }),
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(json?.error ?? `HTTP ${res.status}`);
+  return json;
+}
+
+function InviteClientForm({ onInvited }) {
+  const [email, setEmail] = useState('');
+  const [name, setName] = useState('');
+  const [busy, setBusy] = useState(false);
+  const [msg, setMsg] = useState(null);
+  const [err, setErr] = useState(null);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    setBusy(true); setErr(null); setMsg(null);
+    try {
+      const result = await callInviteClient({ email: email.trim(), name: name.trim() });
+      setMsg(`Sent to ${result.email}. They have 24h to click the link.`);
+      setEmail(''); setName('');
+      onInvited?.();
+    } catch (e) {
+      setErr(e?.message ?? 'Invite failed.');
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  return (
+    <form onSubmit={onSubmit} className="border border-line bg-black/30 p-4 space-y-3">
+      <div className="flex items-center gap-2 label">
+        <Mail size={14} /> Invite a client
+      </div>
+      <div className="grid grid-cols-1 gap-3 md:grid-cols-[1fr_1fr_auto] md:items-end">
+        <Input
+          label="Email"
+          type="email"
+          required
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="darryl@example.com"
+        />
+        <Input
+          label="Name (optional)"
+          value={name}
+          onChange={(e) => setName(e.target.value)}
+          placeholder="Darryl Garner"
+        />
+        <Button type="submit" disabled={busy || !email}>
+          {busy ? 'Sending' : 'Send magic link'}
+        </Button>
+      </div>
+      {msg ? <div className="text-xs uppercase tracking-widest2 text-gold">{msg}</div> : null}
+      {err ? <div role="alert" className="text-xs uppercase tracking-widest2 text-signal">{err}</div> : null}
+      <p className="text-[0.65rem] uppercase tracking-widest2 text-faint">
+        Sends from coach@operatefitness.app. Reply-to is your Gmail.
+      </p>
+    </form>
+  );
+}
 
 function relativeDays(iso) {
   if (!iso) return null;
@@ -26,6 +96,7 @@ export default function Clients() {
   const [q, setQ] = useState('');
   const [plan, setPlan] = useState('all');
   const [loading, setLoading] = useState(true);
+  const [reloadTick, setReloadTick] = useState(0);
 
   useEffect(() => {
     if (!isSupabaseConfigured) {
@@ -66,7 +137,7 @@ export default function Clients() {
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [reloadTick]);
 
   const filtered = useMemo(() => {
     return clients.filter((c) => {
@@ -113,6 +184,8 @@ export default function Clients() {
           <Download size={14} /> Export CSV
         </Button>
       </header>
+
+      <InviteClientForm onInvited={() => setReloadTick((n) => n + 1)} />
 
       <div className="grid grid-cols-1 gap-4 md:grid-cols-[1fr_180px]">
         <Input label="Search" placeholder="Name or email" value={q} onChange={(e) => setQ(e.target.value)} />

--- a/supabase/migrations/0053_client_activation.sql
+++ b/supabase/migrations/0053_client_activation.sql
@@ -1,0 +1,247 @@
+-- 0053_client_activation.sql
+-- Activation loop, P0: when a new client profile lands, two things should
+-- be automatic so the coach view is alive and the client has something to
+-- open the first time they sign in.
+--
+--   1. Bind the client to a coach via coach_client_assignments (default
+--      coach = the first profile with role='coach', stable across re-runs).
+--   2. Clone every program_template marked is_default=true into a new
+--      `programs` row owned by the client, status='active'.
+--
+-- Both happen in a single AFTER INSERT trigger on profiles. The trigger is
+-- security definer so it bypasses RLS — the new client's session has no
+-- insert grant on coach_client_assignments and would not otherwise be
+-- allowed to materialise its own assignment row.
+--
+-- The migration also seeds the first three default templates (Darryl Pilot
+-- Week 1: Push / Pull / Legs), and backfills assignments + programs for any
+-- existing client profile that's missing them (the four dormant pilots that
+-- exist today).
+--
+-- Idempotent end-to-end: re-running this file is a no-op.
+--
+-- Depends on: profiles (0001), programs (0001), coach_client_assignments
+--             (0033), exercises (0002 — for the seed names).
+--
+-- DO NOT auto-apply. Run from the Supabase SQL editor or `supabase db push`.
+
+-- ─── PROGRAM TEMPLATES ───────────────────────────────────────────────────
+-- Template catalogue. Mirrors the programs row shape (schedule + exercises
+-- jsonb) but with no client_id. is_default rows are cloned to every new
+-- client; non-default rows are kept here for the coach to assign manually
+-- via a future UI.
+create table if not exists public.program_templates (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null,
+  schedule    jsonb not null default '{}'::jsonb,
+  exercises   jsonb not null default '[]'::jsonb,
+  is_default  boolean not null default false,
+  order_index int  not null default 0,
+  notes       text,
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+create index if not exists program_templates_default_idx
+  on public.program_templates (is_default, order_index)
+  where is_default = true;
+
+create or replace function public.program_templates_touch_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+drop trigger if exists program_templates_touch_updated_at on public.program_templates;
+create trigger program_templates_touch_updated_at
+  before update on public.program_templates
+  for each row execute function public.program_templates_touch_updated_at();
+
+alter table public.program_templates enable row level security;
+
+-- Any authenticated user can read templates — they're catalogue data.
+drop policy if exists "program_templates read authenticated" on public.program_templates;
+create policy "program_templates read authenticated" on public.program_templates
+  for select using (auth.role() = 'authenticated');
+
+-- Coaches can edit the catalogue. Clients cannot.
+drop policy if exists "program_templates coach write" on public.program_templates;
+create policy "program_templates coach write" on public.program_templates
+  for all using (public.is_coach()) with check (public.is_coach());
+
+-- ─── DEFAULT COACH RESOLUTION ────────────────────────────────────────────
+-- The "default coach" is the oldest profile with role='coach'. v1 is single-
+-- coach (Percy); when multi-coach lands, swap this to read from a settings
+-- table without touching the trigger.
+create or replace function public.default_coach_id()
+returns uuid
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select id from public.profiles
+   where role = 'coach'
+   order by created_at asc
+   limit 1;
+$$;
+
+-- ─── ACTIVATION TRIGGER ──────────────────────────────────────────────────
+-- Fires AFTER INSERT on profiles. Only acts on client rows. Idempotent —
+-- coach_client_assignments has a (coach_id, client_id) unique; we ON CONFLICT
+-- DO NOTHING. Starter program cloning checks for any existing program row
+-- on this client before inserting so re-running the trigger logic against
+-- a backfilled client is a no-op.
+create or replace function public.activate_new_client()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  coach uuid;
+begin
+  if new.role <> 'client' then
+    return new;
+  end if;
+
+  coach := public.default_coach_id();
+
+  -- 1. Coach assignment. Skip silently if no coach exists yet (single-tenant
+  --    cold-start: the first row inserted into profiles is the coach himself).
+  if coach is not null and coach <> new.id then
+    insert into public.coach_client_assignments (coach_id, client_id, is_primary, access_tier)
+    values (coach, new.id, true, 'full')
+    on conflict (coach_id, client_id) do nothing;
+  end if;
+
+  -- 2. Starter programs. Only clone if the client has zero programs yet —
+  --    avoids duplicates when the trigger is re-run (e.g. through backfill).
+  if not exists (select 1 from public.programs where client_id = new.id) then
+    insert into public.programs (client_id, week_number, schedule, exercises, status)
+    select new.id, 1, schedule, exercises, 'active'
+      from public.program_templates
+     where is_default = true
+     order by order_index asc, created_at asc;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists activate_new_client_after_insert on public.profiles;
+create trigger activate_new_client_after_insert
+  after insert on public.profiles
+  for each row execute function public.activate_new_client();
+
+-- ─── SEED: DARRYL PILOT WEEK 1 (Push / Pull / Legs) ──────────────────────
+-- Three templates, all is_default=true, ordered Push → Pull → Legs. Every
+-- new client gets all three cloned active. Exercise names are pulled from
+-- the seeded exercise library (0002) so the workout viewer can resolve cues
+-- and YouTube IDs from public.exercises by name match.
+--
+-- Re-runs: ON CONFLICT (name) DO NOTHING via a unique partial index below
+-- so a second apply does not double-seed. We add the index here rather than
+-- in the column DDL because lower(name) gives us case-insensitive uniqueness
+-- without forcing case on writes.
+create unique index if not exists program_templates_name_lower_idx
+  on public.program_templates (lower(name));
+
+insert into public.program_templates (name, is_default, order_index, schedule, exercises, notes)
+values
+  (
+    'Pilot W1 — Push',
+    true, 1,
+    jsonb_build_object('title', 'Pilot W1 — Push', 'day', 'monday'),
+    jsonb_build_array(
+      jsonb_build_object('name', 'Bench Press',                      'sets', 4, 'reps', '6-8',  'load', 'RPE 7-8'),
+      jsonb_build_object('name', 'Overhead Press',                   'sets', 3, 'reps', '8',    'load', 'RPE 7'),
+      jsonb_build_object('name', 'Incline Bench Press',              'sets', 3, 'reps', '10',   'load', 'RPE 7'),
+      jsonb_build_object('name', 'Seated Dumbbell Shoulder Press',   'sets', 3, 'reps', '10',   'load', 'RPE 8'),
+      jsonb_build_object('name', 'Rope Tricep Pushdown',             'sets', 3, 'reps', '12',   'load', 'RPE 8'),
+      jsonb_build_object('name', 'Lateral Raise',                    'sets', 3, 'reps', '15',   'load', 'controlled, no swing')
+    ),
+    'Pilot week 1, day 1. Calibrate loads on the first set, then push the back-off sets.'
+  ),
+  (
+    'Pilot W1 — Pull',
+    true, 2,
+    jsonb_build_object('title', 'Pilot W1 — Pull', 'day', 'wednesday'),
+    jsonb_build_array(
+      jsonb_build_object('name', 'Conventional Deadlift',  'sets', 3, 'reps', '5',    'load', 'RPE 7'),
+      jsonb_build_object('name', 'Pull-Up',                'sets', 4, 'reps', '6-10', 'load', 'add load if 10 is clean'),
+      jsonb_build_object('name', 'Barbell Row',            'sets', 4, 'reps', '8',    'load', 'RPE 7-8'),
+      jsonb_build_object('name', 'Chest-Supported Row',    'sets', 3, 'reps', '10',   'load', 'RPE 8, 1-sec squeeze'),
+      jsonb_build_object('name', 'Face Pull',              'sets', 3, 'reps', '15',   'load', 'pause at peak'),
+      jsonb_build_object('name', 'EZ-Bar Curl',            'sets', 3, 'reps', '10',   'load', 'RPE 8')
+    ),
+    'Pilot week 1, day 2. Deadlift first; everything else feeds the back.'
+  ),
+  (
+    'Pilot W1 — Legs',
+    true, 3,
+    jsonb_build_object('title', 'Pilot W1 — Legs', 'day', 'friday'),
+    jsonb_build_array(
+      jsonb_build_object('name', 'Back Squat',              'sets', 4, 'reps', '6',     'load', 'RPE 7'),
+      jsonb_build_object('name', 'Romanian Deadlift',       'sets', 3, 'reps', '8',     'load', 'RPE 7'),
+      jsonb_build_object('name', 'Bulgarian Split Squat',   'sets', 3, 'reps', '10/leg','load', 'dumbbells'),
+      jsonb_build_object('name', 'Leg Press',               'sets', 3, 'reps', '12',    'load', 'RPE 8'),
+      jsonb_build_object('name', 'Lying Hamstring Curl',    'sets', 3, 'reps', '12',    'load', 'RPE 8, pause at peak'),
+      jsonb_build_object('name', 'Standing Calf Raise',     'sets', 4, 'reps', '12',    'load', 'full stretch')
+    ),
+    'Pilot week 1, day 3. Squat clean, RDL slow, finish through calves.'
+  )
+on conflict do nothing;
+
+-- ─── BACKFILL ────────────────────────────────────────────────────────────
+-- Run the activation logic for every existing client profile so the four
+-- dormant pilots show up under Percy's roster and have programs to open
+-- the first time they sign in.
+--
+-- Touch-noop UPDATE re-triggers the AFTER INSERT logic? No — INSERT triggers
+-- don't fire on UPDATE. We call the body directly via a do-block instead.
+do $$
+declare
+  c record;
+  coach uuid;
+begin
+  coach := public.default_coach_id();
+  if coach is null then
+    raise notice 'no coach profile found; skipping backfill';
+    return;
+  end if;
+
+  for c in select id from public.profiles where role = 'client' loop
+    if c.id <> coach then
+      insert into public.coach_client_assignments (coach_id, client_id, is_primary, access_tier)
+      values (coach, c.id, true, 'full')
+      on conflict (coach_id, client_id) do nothing;
+    end if;
+
+    if not exists (select 1 from public.programs where client_id = c.id) then
+      insert into public.programs (client_id, week_number, schedule, exercises, status)
+      select c.id, 1, schedule, exercises, 'active'
+        from public.program_templates
+       where is_default = true
+       order by order_index asc, created_at asc;
+    end if;
+  end loop;
+end $$;
+
+-- ─── DOWN (rollback) ─────────────────────────────────────────────────────
+-- Uncomment to roll back this migration. Programs and assignments materialised
+-- by the trigger are intentionally NOT removed — those are client data.
+--
+-- drop trigger  if exists activate_new_client_after_insert on public.profiles;
+-- drop function if exists public.activate_new_client();
+-- drop function if exists public.default_coach_id();
+-- drop policy   if exists "program_templates coach write" on public.program_templates;
+-- drop policy   if exists "program_templates read authenticated" on public.program_templates;
+-- alter table   public.program_templates disable row level security;
+-- drop trigger  if exists program_templates_touch_updated_at on public.program_templates;
+-- drop function if exists public.program_templates_touch_updated_at();
+-- drop index    if exists program_templates_name_lower_idx;
+-- drop index    if exists program_templates_default_idx;
+-- drop table    if exists public.program_templates;

--- a/tests/invite-client.test.js
+++ b/tests/invite-client.test.js
@@ -1,0 +1,193 @@
+// invite-client
+//
+// Coverage targets:
+//   1. Non-POST returns 405
+//   2. Missing auth header → 401 (requireUser throws)
+//   3. Authed client (non-coach) → 403
+//   4. Missing / malformed email → 400
+//   5. Happy path: createUser succeeds, generateLink resolves, Resend mock
+//      fires, response carries email_id + auth_user_id
+//   6. createUser returns "already registered" → still generates link (no throw)
+//   7. RESEND_API_KEY unset → 500 with magic_url surfaced so Percy can
+//      hand it off out-of-band
+//
+// Resend is mocked via global.fetch. No real network.
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+
+const adminAuth = {
+  createUser: vi.fn(),
+  generateLink: vi.fn(),
+};
+const adminClient = { auth: { admin: adminAuth } };
+
+const anonAuth = {
+  getUser: vi.fn(),
+};
+const anonClient = { auth: anonAuth };
+
+const profileQuery = {
+  data: null,
+  select: vi.fn(function () { return this; }),
+  eq: vi.fn(function () { return this; }),
+  maybeSingle: vi.fn(function () { return Promise.resolve({ data: this.data, error: null }); }),
+  __setProfile(p) { this.data = p; return this; },
+};
+
+// Build a mock that returns a fresh chainable profileQuery per call so tests
+// can pre-set the profile shape. requireUser ultimately calls
+// admin.from('profiles').select('*').eq('id', userId).maybeSingle().
+const adminFrom = vi.fn(() => profileQuery);
+adminClient.from = adminFrom;
+
+vi.mock('../netlify/functions/_shared/supabase-admin.js', () => ({
+  getAdminClient: () => adminClient,
+  getAnonClient: () => anonClient,
+}));
+
+vi.mock('../netlify/functions/_shared/owner.js', () => ({
+  isOwnerEmail: (email) => email === 'owner@pkfit.app',
+}));
+
+vi.mock('../netlify/functions/_shared/anthropic.js', () => ({
+  loadPrompt: () =>
+    'SUBJECT: Your PKFIT app is ready\n\n---\n\n{{first_name}},\n\n{{magic_url}}\n\n— Percy\n',
+}));
+
+const originalFetch = global.fetch;
+
+beforeEach(() => {
+  adminAuth.createUser.mockReset();
+  adminAuth.generateLink.mockReset();
+  anonAuth.getUser.mockReset();
+  adminFrom.mockClear();
+  profileQuery.data = null;
+
+  // default: a coach makes the call
+  anonAuth.getUser.mockResolvedValue({
+    data: { user: { id: 'coach-1', email: 'percy@pkfit.app' } },
+    error: null,
+  });
+  profileQuery.__setProfile({ id: 'coach-1', role: 'coach' });
+
+  adminAuth.createUser.mockResolvedValue({
+    data: { user: { id: 'new-user-1' } },
+    error: null,
+  });
+  adminAuth.generateLink.mockResolvedValue({
+    data: { properties: { action_link: 'https://app.pkfit.app/magic#token=abc' } },
+    error: null,
+  });
+
+  global.fetch = vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve({ id: 'em_42' }),
+    text: () => Promise.resolve(''),
+  });
+
+  process.env.RESEND_API_KEY = 'test-key';
+  process.env.VITE_SUPABASE_URL = 'https://test.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service';
+  process.env.VITE_SUPABASE_ANON_KEY = 'anon';
+});
+
+afterEach(() => {
+  global.fetch = originalFetch;
+  delete process.env.RESEND_API_KEY;
+});
+
+function makeEvent({ method = 'POST', body = { email: 'darryl@example.com', name: 'Darryl Garner' }, auth = 'Bearer good-token' } = {}) {
+  return {
+    httpMethod: method,
+    headers: { authorization: auth },
+    body: typeof body === 'string' ? body : JSON.stringify(body),
+  };
+}
+
+async function loadHandler() {
+  const mod = await import('../netlify/functions/invite-client.js');
+  return mod.handler;
+}
+
+describe('invite-client', () => {
+  it('rejects non-POST with 405', async () => {
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({ method: 'GET' }));
+    expect(res.statusCode).toBe(405);
+  });
+
+  it('rejects unauthenticated calls with 401', async () => {
+    anonAuth.getUser.mockResolvedValue({ data: null, error: { message: 'bad jwt' } });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('rejects non-coach callers with 403', async () => {
+    profileQuery.__setProfile({ id: 'coach-1', role: 'client' });
+    anonAuth.getUser.mockResolvedValue({
+      data: { user: { id: 'coach-1', email: 'random@example.com' } },
+      error: null,
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(403);
+  });
+
+  it('rejects missing email with 400', async () => {
+    const handler = await loadHandler();
+    const res = await handler(makeEvent({ body: { name: 'no email' } }));
+    expect(res.statusCode).toBe(400);
+  });
+
+  it('happy path: creates user, generates magic link, sends Resend email', async () => {
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body);
+    expect(payload.ok).toBe(true);
+    expect(payload.email).toBe('darryl@example.com');
+    expect(payload.email_id).toBe('em_42');
+    expect(adminAuth.createUser).toHaveBeenCalledWith(expect.objectContaining({
+      email: 'darryl@example.com',
+      email_confirm: true,
+      user_metadata: { name: 'Darryl Garner' },
+    }));
+    expect(adminAuth.generateLink).toHaveBeenCalledWith(expect.objectContaining({
+      type: 'magiclink',
+      email: 'darryl@example.com',
+    }));
+    const fetchArgs = global.fetch.mock.calls[0];
+    expect(fetchArgs[0]).toBe('https://api.resend.com/emails');
+    const sentBody = JSON.parse(fetchArgs[1].body);
+    expect(sentBody.from).toContain('coach@operatefitness.app');
+    expect(sentBody.reply_to).toBe('percyhendrux123@gmail.com');
+    expect(sentBody.subject).toBe('Your PKFIT app is ready');
+    expect(sentBody.text).toContain('Darryl,');
+    expect(sentBody.text).toContain('https://app.pkfit.app/magic#token=abc');
+  });
+
+  it('treats "already registered" from createUser as a soft success', async () => {
+    adminAuth.createUser.mockResolvedValue({
+      data: null,
+      error: { message: 'A user with this email address has already been registered' },
+    });
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(200);
+    const payload = JSON.parse(res.body);
+    expect(payload.ok).toBe(true);
+    expect(payload.auth_user_id).toBeNull();
+  });
+
+  it('surfaces magic_url when RESEND_API_KEY is unset (500)', async () => {
+    delete process.env.RESEND_API_KEY;
+    const handler = await loadHandler();
+    const res = await handler(makeEvent());
+    expect(res.statusCode).toBe(500);
+    const payload = JSON.parse(res.body);
+    expect(payload.error).toMatch(/RESEND_API_KEY/);
+    expect(payload.magic_url).toBe('https://app.pkfit.app/magic#token=abc');
+  });
+});


### PR DESCRIPTION
## Summary

Ships the P0 activation stack so a new client signs in, sees a coach, and opens a pre-loaded workout the first time they land:

- **0053 migration** — `program_templates` table + `activate_new_client` AFTER INSERT trigger on `profiles`. Every new client → `coach_client_assignments` row + three Pilot W1 programs (Push/Pull/Legs) cloned active. Backfills the four dormant pilot profiles.
- **`invite-client` Netlify function** — creates auth user if missing, generates a magic link via the admin API, sends from `coach@operatefitness.app` via Resend with `reply-to: percyhendrux123@gmail.com`. 401/403/400 gated; surfaces `magic_url` when `RESEND_API_KEY` is unset so the link can be handed off out-of-band.
- **Coach roster UI** — inline invite form (email + optional name) at the top of `/coach/clients`, wired to the function; refreshes the table on success.
- **Tests** — 7 scenarios on invite-client (auth, validation, happy path, already-exists soft-success, no-provider fallback). All pass locally.

Stripe, push subscriptions, intake forms, and the PKai assistant code are **untouched**.

## Deploy notes (read before merge)

1. **Apply migration** in the Supabase SQL editor before merge: paste `supabase/migrations/0053_client_activation.sql` and run. Verify `select count(*) from program_templates where is_default = true;` returns 3, and `select count(*) from coach_client_assignments;` is no longer 0.
2. **Verify Netlify env** has `RESEND_API_KEY`, `SUPABASE_SERVICE_ROLE_KEY`, `VITE_SITE_URL`. Optionally `INVITE_FROM_EMAIL` + `INVITE_REPLY_TO` (defaults are `coach@operatefitness.app` and `percyhendrux123@gmail.com`).
3. **Test invite** with `percyhendrux123+test@gmail.com` from the coach roster page after deploy. The `+test` alias is needed because the bare Gmail is in `OWNER_EMAILS` and would route as owner not client.

## Test plan

- [ ] Apply migration 0053 in Supabase; confirm 3 templates + 4 assignments + 12 cloned programs
- [ ] Trigger preview deploy; verify the function shows up under `/.netlify/functions/`
- [ ] From the coach roster, invite `percyhendrux123+test@gmail.com`
- [ ] Verify the email lands in Gmail (subject: "Your PKFIT app is ready", from `coach@operatefitness.app`)
- [ ] Click the magic link → confirms sign-in lands at `/home`
- [ ] Open `/workouts` → three active "Pilot W1 — …" programs visible
- [ ] Log a session against one of them → row in `workout_sessions`
- [ ] If all green, invite Darryl from the same form

🤖 Generated with [Claude Code](https://claude.com/claude-code)