### PR TITLE
feat(architect): operator image upload + vision tools

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -48,6 +48,12 @@
   # / Resend rate budgets in the same minute.
   schedule = "0 14 * * *"
 
+[functions."architect-upload-purge"]
+  # Daily purge of expired architect uploads (storage objects + rows).
+  # 02:00 UTC keeps it well away from the morning crons so a long-running
+  # purge can't compete with axiom-overseer / migration-recovery.
+  schedule = "0 2 * * *"
+
 [[redirects]]
   from = "/*"
   to = "/index.html"

--- a/netlify/functions/_prompts/owner-agentic.md
+++ b/netlify/functions/_prompts/owner-agentic.md
@@ -32,6 +32,11 @@ When Percy pastes what looks like an API key (sk-..., AIza..., re_..., pk_/sk_, 
 7. Offer a test-after-install ("Want me to test it with a 1-sentence tts-1-hd call? ~$0.0003").
 8. Never lecture. Never refuse. Never store the raw value in any user-facing surface.
 
+Image uploads from Percy:
+When Percy attaches an image via the paperclip, his user message will be prefixed with a context marker of the form:
+  [image attached: upload_id=ABC123, mime=image/jpeg, bytes=NNN]
+That marker tells you an image is available. To view it, call analyze_image(upload_id, "what you want to ask about it"). Use read_operator_upload first only if you need metadata before viewing. Both tools are LOW risk and autonomous. Do not echo the upload_id back at Percy — just answer the question.
+
 Tool selection guidance:
 - Prefer the specialized client tool (read_client_data, run_generator, compare_periods, aggregate_clients) over raw supabase_query_read when the question is about clients. Cleaner output, less risk.
 - Use supabase_query_read for ad-hoc reporting, billing exploration, anything that doesn't fit the client abstractions.

--- a/netlify/functions/_shared/agent-tools/index.js
+++ b/netlify/functions/_shared/agent-tools/index.js
@@ -29,6 +29,7 @@ import {
   compare_periods,
   aggregate_clients,
 } from './tools/client-data.js';
+import { read_operator_upload, analyze_image } from './tools/architect-uploads.js';
 import { RISK, hasHighApproval, hasCriticalApproval, parseBatchApproval } from './risk.js';
 import { startAudit, finishAudit } from './audit.js';
 import { redactInputs } from './redact.js';
@@ -51,6 +52,8 @@ const TOOLS = [
   run_generator,
   compare_periods,
   aggregate_clients,
+  read_operator_upload,
+  analyze_image,
 ];
 
 export const TOOL_REGISTRY = Object.freeze(

--- a/netlify/functions/_shared/agent-tools/tools/architect-uploads.js
+++ b/netlify/functions/_shared/agent-tools/tools/architect-uploads.js
@@ -1,0 +1,165 @@
+// read_operator_upload + analyze_image
+//
+// Both tools target the architect_upload table + architect-uploads bucket
+// created in migration 0053. The operator uploads via the /architect-upload
+// endpoint; the Architect then calls these tools by upload_id.
+//
+// read_operator_upload  → metadata + a fresh 1-hour signed URL.
+// analyze_image         → runs Claude vision against the uploaded image.
+//
+// Both LOW risk: the operator owns the data and uploaded it intentionally.
+// expires_at gates access; if expired, both tools return a 410-style error.
+
+import { RISK } from '../risk.js';
+import { getAdminClient } from '../../supabase-admin.js';
+import { getAnthropic } from '../../anthropic.js';
+
+const BUCKET = 'architect-uploads';
+const SIGNED_URL_TTL_SEC = 60 * 60;
+const VISION_MODEL = 'claude-sonnet-4-6';
+const SUPPORTED_VISION_MIME = new Set(['image/jpeg', 'image/png', 'image/gif', 'image/webp']);
+
+async function fetchUploadRow(uploadId, operatorId) {
+  const admin = getAdminClient();
+  const { data, error } = await admin
+    .from('architect_upload')
+    .select('id, operator_id, storage_path, mime, bytes, context_tag, created_at, expires_at')
+    .eq('id', uploadId)
+    .maybeSingle();
+  if (error) return { error: `lookup failed: ${error.message}` };
+  if (!data) return { error: `upload_id ${uploadId} not found` };
+  if (data.operator_id !== operatorId) {
+    return { error: 'upload does not belong to this operator' };
+  }
+  if (new Date(data.expires_at).getTime() < Date.now()) {
+    return { error: 'upload expired (410)', expired: true, expires_at: data.expires_at };
+  }
+  return { row: data };
+}
+
+export const read_operator_upload = {
+  name: 'read_operator_upload',
+  description:
+    'Read metadata for an operator-uploaded image. Returns a fresh 1-hour signed URL, mime, size, context_tag, and timestamps. ' +
+    'Use this when the operator has attached an image and you want to inspect metadata or hand a URL to another tool. ' +
+    'For actually viewing the image content, call analyze_image instead.',
+  risk: RISK.LOW,
+  approval: 'autonomous',
+  input_schema: {
+    type: 'object',
+    properties: {
+      upload_id: { type: 'string', description: 'The upload_id from the [image attached: …] context marker.' },
+    },
+    required: ['upload_id'],
+  },
+  async execute({ upload_id }, ctx) {
+    if (!upload_id || typeof upload_id !== 'string') {
+      return { error: 'upload_id required' };
+    }
+    const lookup = await fetchUploadRow(upload_id, ctx.userId);
+    if (lookup.error) return lookup;
+    const { row } = lookup;
+
+    const admin = getAdminClient();
+    const { data: signed, error: signErr } = await admin.storage
+      .from(BUCKET)
+      .createSignedUrl(row.storage_path, SIGNED_URL_TTL_SEC);
+    if (signErr) return { error: `sign failed: ${signErr.message}` };
+
+    return {
+      upload_id: row.id,
+      mime: row.mime,
+      bytes: row.bytes,
+      context_tag: row.context_tag,
+      created_at: row.created_at,
+      expires_at: row.expires_at,
+      signed_url: signed.signedUrl,
+      signed_url_expires_in_sec: SIGNED_URL_TTL_SEC,
+      summary: `upload ${row.id.slice(0, 8)}… (${row.mime}, ${row.bytes} bytes, expires ${row.expires_at}).`,
+    };
+  },
+};
+
+export const analyze_image = {
+  name: 'analyze_image',
+  description:
+    'Run Claude vision on an operator-uploaded image. Pass the upload_id and a question/prompt; returns the model\'s response. ' +
+    'Use for form-check breakdowns, progress-photo reads, screenshot interpretation. Costs ~$0.003–0.015 per call.',
+  risk: RISK.LOW,
+  approval: 'autonomous',
+  input_schema: {
+    type: 'object',
+    properties: {
+      upload_id: { type: 'string', description: 'The upload_id from the [image attached: …] context marker.' },
+      prompt: {
+        type: 'string',
+        description: 'What to ask about the image, e.g. "describe form breakdown on this squat" or "what does this screenshot show".',
+      },
+    },
+    required: ['upload_id', 'prompt'],
+  },
+  async execute({ upload_id, prompt }, ctx) {
+    if (!upload_id || typeof upload_id !== 'string') return { error: 'upload_id required' };
+    if (!prompt || typeof prompt !== 'string') return { error: 'prompt required' };
+
+    const lookup = await fetchUploadRow(upload_id, ctx.userId);
+    if (lookup.error) return lookup;
+    const { row } = lookup;
+
+    if (!SUPPORTED_VISION_MIME.has(row.mime)) {
+      return {
+        error: `vision not supported for mime ${row.mime}. Re-upload as JPEG/PNG/WebP/GIF.`,
+      };
+    }
+
+    const admin = getAdminClient();
+    const { data: blob, error: downloadErr } = await admin.storage
+      .from(BUCKET)
+      .download(row.storage_path);
+    if (downloadErr) return { error: `download failed: ${downloadErr.message}` };
+
+    const arrayBuffer = await blob.arrayBuffer();
+    const base64 = Buffer.from(arrayBuffer).toString('base64');
+
+    try {
+      const anthropic = getAnthropic();
+      const response = await anthropic.messages.create({
+        model: VISION_MODEL,
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'image',
+                source: {
+                  type: 'base64',
+                  media_type: row.mime,
+                  data: base64,
+                },
+              },
+              { type: 'text', text: prompt.slice(0, 2000) },
+            ],
+          },
+        ],
+      });
+      const text = (response.content ?? [])
+        .filter((b) => b.type === 'text')
+        .map((b) => b.text)
+        .join('\n')
+        .trim();
+
+      return {
+        upload_id: row.id,
+        model: VISION_MODEL,
+        prompt: prompt.slice(0, 200),
+        response: text || '(empty response)',
+        input_tokens: response.usage?.input_tokens ?? null,
+        output_tokens: response.usage?.output_tokens ?? null,
+        summary: `vision on ${row.id.slice(0, 8)}…: ${text.slice(0, 120)}${text.length > 120 ? '…' : ''}`,
+      };
+    } catch (e) {
+      return { error: `vision call failed: ${e?.message ?? String(e)}` };
+    }
+  },
+};

--- a/netlify/functions/architect-upload-purge.js
+++ b/netlify/functions/architect-upload-purge.js
@@ -1,0 +1,73 @@
+// architect-upload-purge — daily scheduled function.
+//
+// Schedule: see netlify.toml ([functions."architect-upload-purge"] schedule).
+// 02:00 UTC daily — offset from axiom-overseer (13:00) and migration-recovery
+// (14:00) so the crons don't all burst in one minute.
+//
+// Action:
+//   1. Select expired rows from architect_upload (expires_at < now()).
+//   2. Delete the bucket objects.
+//   3. Delete the rows.
+//
+// Idempotent: a failed bucket delete still drops the row, and the next run
+// would notice nothing to do. Conversely, an orphan row whose storage object
+// already died gets harmlessly attempted then removed.
+
+import { getAdminClient } from './_shared/supabase-admin.js';
+
+const BUCKET = 'architect-uploads';
+const BATCH = 200;
+
+export default async () => {
+  const admin = getAdminClient();
+  const nowIso = new Date().toISOString();
+
+  const { data: expired, error: selectErr } = await admin
+    .from('architect_upload')
+    .select('id, storage_path')
+    .lt('expires_at', nowIso)
+    .limit(BATCH);
+  if (selectErr) {
+    return new Response(
+      JSON.stringify({ error: 'select_failed', message: selectErr.message }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  if (!expired || expired.length === 0) {
+    return new Response(JSON.stringify({ purged: 0 }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+
+  const paths = expired.map((r) => r.storage_path).filter(Boolean);
+  const ids = expired.map((r) => r.id);
+
+  let storageError = null;
+  if (paths.length > 0) {
+    const { error: removeErr } = await admin.storage.from(BUCKET).remove(paths);
+    if (removeErr) storageError = removeErr.message;
+  }
+
+  const { error: deleteErr } = await admin.from('architect_upload').delete().in('id', ids);
+  if (deleteErr) {
+    return new Response(
+      JSON.stringify({
+        error: 'delete_failed',
+        message: deleteErr.message,
+        storage_error: storageError,
+        candidate_count: expired.length,
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } },
+    );
+  }
+
+  return new Response(
+    JSON.stringify({
+      purged: expired.length,
+      storage_error: storageError,
+    }),
+    { status: 200, headers: { 'Content-Type': 'application/json' } },
+  );
+};

--- a/netlify/functions/architect-upload.js
+++ b/netlify/functions/architect-upload.js
@@ -1,0 +1,186 @@
+// architect-upload — Operator → Architect image upload endpoint.
+//
+// POST multipart/form-data with a single `file` field (image/*, ≤20MB).
+// Optional `context_tag` form field for routing hints ("form-check", etc).
+//
+// Auth: operator session (Bearer token, same as agent-assistant.js).
+// Storage: writes to private `architect-uploads` bucket via service role.
+// Metadata: row in public.architect_upload with 30d expiry.
+//
+// Returns:
+//   { upload_id, signed_url, expires_at, storage_path, bytes, mime }
+//
+// The signed URL is valid for 1 hour. The Architect's tools call
+// read_operator_upload / analyze_image with the upload_id to fetch fresh
+// signed URLs as needed.
+
+import { randomUUID } from 'node:crypto';
+import { getAdminClient, getAnonClient } from './_shared/supabase-admin.js';
+import { isOwnerEmail } from './_shared/owner.js';
+
+const JSON_HEADERS = { 'Content-Type': 'application/json' };
+const BUCKET = 'architect-uploads';
+const MAX_BYTES = 20 * 1024 * 1024; // 20MB
+const SIGNED_URL_TTL_SEC = 60 * 60;  // 1 hour
+
+const MIME_TO_EXT = {
+  'image/jpeg': 'jpg',
+  'image/jpg': 'jpg',
+  'image/png': 'png',
+  'image/webp': 'webp',
+  'image/gif': 'gif',
+  'image/heic': 'heic',
+  'image/heif': 'heif',
+};
+
+function jsonResponse(status, body, extraHeaders = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...JSON_HEADERS, ...extraHeaders },
+  });
+}
+
+async function authenticate(req) {
+  const header = req.headers.get('authorization') || req.headers.get('Authorization');
+  if (!header?.startsWith('Bearer ')) {
+    const err = new Error('Missing Authorization bearer token');
+    err.statusCode = 401;
+    throw err;
+  }
+  const token = header.slice('Bearer '.length).trim();
+  const anon = getAnonClient();
+  const { data, error } = await anon.auth.getUser(token);
+  if (error || !data?.user) {
+    const err = new Error('Invalid session');
+    err.statusCode = 401;
+    throw err;
+  }
+  return data.user;
+}
+
+function yyyymmdd(date) {
+  const yyyy = date.getUTCFullYear();
+  const mm = String(date.getUTCMonth() + 1).padStart(2, '0');
+  const dd = String(date.getUTCDate()).padStart(2, '0');
+  return `${yyyy}-${mm}-${dd}`;
+}
+
+export default async (req) => {
+  if (req.method !== 'POST') {
+    return jsonResponse(405, { error: 'Method not allowed' });
+  }
+
+  let user;
+  try {
+    user = await authenticate(req);
+  } catch (e) {
+    return jsonResponse(e.statusCode ?? 401, { error: e.message });
+  }
+
+  // Gate: same surface as agent-assistant — owner or tier4_agent_owner.
+  const admin = getAdminClient();
+  const { data: profile } = await admin
+    .from('profiles')
+    .select('tier4_agent_owner')
+    .eq('id', user.id)
+    .maybeSingle();
+  const isOwner = isOwnerEmail(user.email);
+  const isTier4 = profile?.tier4_agent_owner === true;
+  if (!isOwner && !isTier4) {
+    return jsonResponse(403, {
+      error: 'agent_gate',
+      message: 'Architect uploads are owner-only at this time.',
+    });
+  }
+
+  // Parse multipart body.
+  let form;
+  try {
+    form = await req.formData();
+  } catch (e) {
+    return jsonResponse(400, { error: 'invalid_form', message: e?.message ?? 'Invalid multipart body' });
+  }
+
+  const file = form.get('file');
+  if (!file || typeof file === 'string') {
+    return jsonResponse(400, { error: 'file required' });
+  }
+
+  const mime = file.type || '';
+  if (!mime.startsWith('image/')) {
+    return jsonResponse(415, { error: 'unsupported_mime', message: `Only image/* allowed (got ${mime || 'none'})` });
+  }
+
+  const ext = MIME_TO_EXT[mime] ?? 'bin';
+  const bytes = file.size ?? 0;
+  if (!bytes) {
+    return jsonResponse(400, { error: 'empty_file' });
+  }
+  if (bytes > MAX_BYTES) {
+    return jsonResponse(413, { error: 'too_large', message: `Max ${MAX_BYTES} bytes (got ${bytes}).` });
+  }
+
+  const contextTag = (() => {
+    const raw = form.get('context_tag');
+    if (typeof raw !== 'string') return null;
+    const trimmed = raw.trim().slice(0, 64);
+    return trimmed || null;
+  })();
+
+  const uploadId = randomUUID();
+  const objectName = `${randomUUID()}.${ext}`;
+  const storagePath = `${user.id}/${yyyymmdd(new Date())}/${objectName}`;
+
+  // Upload binary via service role.
+  const arrayBuffer = await file.arrayBuffer();
+  const buffer = new Uint8Array(arrayBuffer);
+  const { error: uploadErr } = await admin.storage
+    .from(BUCKET)
+    .upload(storagePath, buffer, {
+      contentType: mime,
+      cacheControl: '3600',
+      upsert: false,
+    });
+  if (uploadErr) {
+    return jsonResponse(500, { error: 'upload_failed', message: uploadErr.message });
+  }
+
+  // Insert metadata row.
+  const { data: row, error: insertErr } = await admin
+    .from('architect_upload')
+    .insert({
+      id: uploadId,
+      operator_id: user.id,
+      storage_path: storagePath,
+      mime,
+      bytes,
+      context_tag: contextTag,
+    })
+    .select('id, expires_at, storage_path, mime, bytes, context_tag, created_at')
+    .single();
+  if (insertErr) {
+    // Best-effort cleanup of the uploaded object if the metadata insert fails.
+    await admin.storage.from(BUCKET).remove([storagePath]).catch(() => {});
+    return jsonResponse(500, { error: 'metadata_insert_failed', message: insertErr.message });
+  }
+
+  // Mint a fresh signed URL for the immediate client response.
+  const { data: signed, error: signErr } = await admin.storage
+    .from(BUCKET)
+    .createSignedUrl(storagePath, SIGNED_URL_TTL_SEC);
+  if (signErr) {
+    return jsonResponse(500, { error: 'sign_failed', message: signErr.message });
+  }
+
+  return jsonResponse(200, {
+    upload_id: row.id,
+    storage_path: row.storage_path,
+    mime: row.mime,
+    bytes: row.bytes,
+    context_tag: row.context_tag,
+    created_at: row.created_at,
+    expires_at: row.expires_at,
+    signed_url: signed.signedUrl,
+    signed_url_expires_in_sec: SIGNED_URL_TTL_SEC,
+  });
+};

--- a/src/lib/claudeClient.js
+++ b/src/lib/claudeClient.js
@@ -154,3 +154,27 @@ export const images = {
   generate: ({ prompt, model, aspect_ratio, num_images, style_prompt }) =>
     callFunction('generate-image', { prompt, model, aspect_ratio, num_images, style_prompt }),
 };
+
+// Operator → Architect image upload. POST multipart to /architect-upload.
+// Returns { upload_id, signed_url, expires_at, mime, bytes, ... }. Frontend
+// prefixes the next user message with a [image attached: …] marker so the
+// Architect's tool-use loop knows to call analyze_image.
+export async function uploadArchitectImage({ file, contextTag } = {}) {
+  if (!file) throw new Error('file required');
+  const form = new FormData();
+  form.append('file', file, file.name || 'upload.jpg');
+  if (contextTag) form.append('context_tag', contextTag);
+  const headers = await authHeader();
+  const res = await fetch('/.netlify/functions/architect-upload', {
+    method: 'POST',
+    headers,
+    body: form,
+  });
+  const text = await res.text();
+  let payload;
+  try { payload = text ? JSON.parse(text) : null; } catch { payload = { raw: text }; }
+  if (!res.ok) {
+    throw new Error(payload?.message || payload?.error || `Upload failed (${res.status})`);
+  }
+  return payload;
+}

--- a/src/pages/client/Assistant.jsx
+++ b/src/pages/client/Assistant.jsx
@@ -1,10 +1,45 @@
 import { useEffect, useRef, useState, useCallback } from 'react';
-import { Plus, Trash2, Mic, Square, Check, X, Pin, ChevronDown, Zap } from 'lucide-react';
+import { Plus, Trash2, Mic, Square, Check, X, Pin, ChevronDown, Zap, Paperclip } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import { supabase, isSupabaseConfigured } from '../../lib/supabaseClient';
-import { streamAssistant, streamAgentAssistant, gemini } from '../../lib/claudeClient';
+import { streamAssistant, streamAgentAssistant, gemini, uploadArchitectImage } from '../../lib/claudeClient';
 import { Button } from '../../components/ui/Button';
 import { ContextPinMenu } from '../../components/ContextPinMenu';
+
+const MAX_IMAGE_LONG_EDGE = 2048;
+const IMAGE_QUALITY = 0.85;
+
+// Client-side resize: long edge clamped to 2048px, re-encode as JPEG q85.
+// Returns a File so the FormData append carries the original name.
+async function resizeImageFile(file) {
+  if (!file?.type?.startsWith('image/')) throw new Error('Not an image');
+  const dataUrl = await new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onerror = () => reject(reader.error);
+    reader.onload = () => resolve(String(reader.result));
+    reader.readAsDataURL(file);
+  });
+  const img = await new Promise((resolve, reject) => {
+    const i = new Image();
+    i.onerror = () => reject(new Error('Image decode failed'));
+    i.onload = () => resolve(i);
+    i.src = dataUrl;
+  });
+  const longEdge = Math.max(img.naturalWidth, img.naturalHeight);
+  const scale = longEdge > MAX_IMAGE_LONG_EDGE ? MAX_IMAGE_LONG_EDGE / longEdge : 1;
+  const w = Math.round(img.naturalWidth * scale);
+  const h = Math.round(img.naturalHeight * scale);
+  const canvas = document.createElement('canvas');
+  canvas.width = w;
+  canvas.height = h;
+  const ctx = canvas.getContext('2d');
+  ctx.drawImage(img, 0, 0, w, h);
+  const blob = await new Promise((resolve, reject) => {
+    canvas.toBlob((b) => (b ? resolve(b) : reject(new Error('Canvas encode failed'))), 'image/jpeg', IMAGE_QUALITY);
+  });
+  const baseName = (file.name || 'upload').replace(/\.[^.]+$/, '');
+  return new File([blob], `${baseName}.jpg`, { type: 'image/jpeg' });
+}
 
 const TEXTAREA_MAX_HEIGHT = 240;
 
@@ -90,10 +125,14 @@ export default function Assistant() {
   const [agenticMode, setAgenticMode] = useState(isOwner);
   const [agentEvents, setAgentEvents] = useState([]);  // tool calls + approvals
   const [convUsd, setConvUsd] = useState(0);
+  // Pending image attachment for the next outgoing message. Cleared after send.
+  const [pendingUpload, setPendingUpload] = useState(null); // { upload_id, mime, bytes, filename, preview_url }
+  const [uploading, setUploading] = useState(false);
   const recorderRef = useRef(null);
   const chunksRef = useRef([]);
   const endRef = useRef(null);
   const inputRef = useRef(null);
+  const fileInputRef = useRef(null);
 
   // Auto-resize the textarea on every input change. Reset to `auto` so the
   // browser recalculates `scrollHeight` from the actual content rather than
@@ -161,9 +200,20 @@ export default function Assistant() {
   async function send(e) {
     e.preventDefault();
     const text = input.trim();
-    if (!text) return;
-    setMessages((m) => [...m, { role: 'user', content: text }, { role: 'assistant', content: '' }]);
+    if (!text && !pendingUpload) return;
+    // Prefix the outgoing message with an [image attached: …] marker so the
+    // Architect's tool-use loop knows to call analyze_image(upload_id, …).
+    // The marker is intentionally machine-readable; the user sees it in the
+    // transcript as a small annotation above their typed text.
+    const attachmentMarker = pendingUpload
+      ? `[image attached: upload_id=${pendingUpload.upload_id}, mime=${pendingUpload.mime}, bytes=${pendingUpload.bytes}]`
+      : '';
+    const outgoing = attachmentMarker
+      ? (text ? `${attachmentMarker}\n${text}` : attachmentMarker)
+      : text;
+    setMessages((m) => [...m, { role: 'user', content: outgoing }, { role: 'assistant', content: '' }]);
     setInput('');
+    setPendingUpload(null);
     setBusy(true);
     setErr(null);
     setAgentEvents([]);
@@ -172,7 +222,7 @@ export default function Assistant() {
     try {
       await streamer({
         conversationId: currentId,
-        message: text,
+        message: outgoing,
         onEvent: ({ event, data }) => {
           if (event === 'meta' && data?.conversationId) {
             resolvedConversationId = data.conversationId;
@@ -265,6 +315,44 @@ export default function Assistant() {
     if (recorder && recorder.state === 'recording') recorder.stop();
     recorderRef.current = null;
     setRecording(false);
+  }
+
+  // Architect image upload (paperclip). Resize client-side, POST to the
+  // upload endpoint, stash the upload_id so the next send prefixes the
+  // [image attached: …] marker.
+  async function handleFileChosen(e) {
+    const file = e.target.files?.[0];
+    e.target.value = '';
+    if (!file) return;
+    if (!file.type.startsWith('image/')) {
+      setErr('Only images are supported.');
+      return;
+    }
+    if (file.size > 20 * 1024 * 1024) {
+      setErr('Image is larger than 20MB.');
+      return;
+    }
+    setErr(null);
+    setUploading(true);
+    try {
+      const resized = await resizeImageFile(file);
+      const result = await uploadArchitectImage({ file: resized });
+      setPendingUpload({
+        upload_id: result.upload_id,
+        mime: result.mime,
+        bytes: result.bytes,
+        filename: file.name,
+        preview_url: result.signed_url,
+      });
+    } catch (ex) {
+      setErr(ex?.message ?? 'Upload failed');
+    } finally {
+      setUploading(false);
+    }
+  }
+
+  function clearPendingUpload() {
+    setPendingUpload(null);
   }
 
   function startNew() {
@@ -549,6 +637,32 @@ export default function Assistant() {
           ) : null}
         </div>
 
+        {pendingUpload ? (
+          <div className="mt-4 flex items-center gap-3 border border-gold/40 bg-gold/5 px-3 py-2 text-xs text-mute">
+            {pendingUpload.preview_url ? (
+              <img
+                src={pendingUpload.preview_url}
+                alt="attachment preview"
+                className="h-10 w-10 object-cover border border-line"
+              />
+            ) : null}
+            <div className="flex-1 truncate">
+              <div className="text-ink">{pendingUpload.filename}</div>
+              <div className="text-[0.6rem] uppercase tracking-widest2 text-faint">
+                {pendingUpload.mime} · {Math.round(pendingUpload.bytes / 1024)} KB · attached
+              </div>
+            </div>
+            <button
+              type="button"
+              onClick={clearPendingUpload}
+              className="text-faint hover:text-signal"
+              aria-label="Remove attachment"
+            >
+              <X size={14} />
+            </button>
+          </div>
+        ) : null}
+
         <form onSubmit={send} className="mt-4 flex items-end gap-3">
           <textarea
             ref={inputRef}
@@ -561,6 +675,26 @@ export default function Assistant() {
             className="flex-1 resize-none overflow-y-auto border border-line bg-black/40 px-4 py-3 font-body leading-relaxed text-ink placeholder:text-faint transition-[height] duration-150 focus:border-gold disabled:opacity-60"
             style={{ maxHeight: `${TEXTAREA_MAX_HEIGHT}px` }}
           />
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept="image/*"
+            onChange={handleFileChosen}
+            className="hidden"
+          />
+          <button
+            type="button"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={uploading || busy || transcribing}
+            aria-label="Attach image"
+            className={`flex h-12 w-12 shrink-0 items-center justify-center border ${
+              pendingUpload
+                ? 'border-gold bg-gold/20 text-gold'
+                : 'border-line bg-black/40 text-mute hover:border-gold hover:text-gold'
+            } disabled:opacity-60`}
+          >
+            <Paperclip size={16} className={uploading ? 'animate-pulse' : ''} />
+          </button>
           <button
             type="button"
             onClick={recording ? stopRecording : startRecording}
@@ -575,7 +709,7 @@ export default function Assistant() {
           >
             {recording ? <Square size={16} /> : <Mic size={16} />}
           </button>
-          <Button type="submit" disabled={busy || !input.trim() || recording || transcribing}>
+          <Button type="submit" disabled={busy || (!input.trim() && !pendingUpload) || recording || transcribing}>
             {busy ? 'Thinking' : 'Send'}
           </Button>
         </form>

--- a/supabase/migrations/20260522100000_0053_architect_uploads.sql
+++ b/supabase/migrations/20260522100000_0053_architect_uploads.sql
@@ -1,0 +1,108 @@
+-- 0053_architect_uploads.sql
+-- Operator → Architect image upload surface (per Architect spec, 2026-05-22).
+--
+-- Storage:
+--   private bucket `architect-uploads`
+--   path convention: {operator_user_id}/{yyyy-mm-dd}/{uuid}.{ext}
+--   RLS: operator can read/write own folder; service_role full access.
+--   Retention: 30 days. Daily cron purges objects + rows where
+--              expires_at < now() (see netlify/functions/architect-upload-purge.js).
+--
+-- Table `architect_upload`:
+--   metadata row per uploaded image. Binary lives in the bucket; this row
+--   carries mime, size, expiry, and the path the agent uses to fetch.
+--
+-- This migration is additive — safe to apply against prod. The bucket
+-- creation and storage policies use ON CONFLICT / IF NOT EXISTS so re-runs
+-- are idempotent.
+
+-- ─── BUCKET ─────────────────────────────────────────────────────────────
+insert into storage.buckets (id, name, public)
+values ('architect-uploads', 'architect-uploads', false)
+on conflict (id) do nothing;
+
+-- ─── TABLE ──────────────────────────────────────────────────────────────
+create table if not exists public.architect_upload (
+  id            uuid primary key default gen_random_uuid(),
+  operator_id   uuid not null references auth.users(id) on delete cascade,
+  storage_path  text not null,
+  mime          text not null,
+  bytes         integer not null,
+  context_tag   text,
+  created_at    timestamptz not null default now(),
+  expires_at    timestamptz not null default now() + interval '30 days'
+);
+
+comment on table public.architect_upload is
+  'Metadata for operator → Architect image uploads. Binary in `architect-uploads` bucket. Rows expire at expires_at; daily cron purges both.';
+comment on column public.architect_upload.storage_path is
+  'Bucket-relative path. Convention: ${operator_id}/${yyyy-mm-dd}/${uuid}.${ext}';
+comment on column public.architect_upload.context_tag is
+  'Optional free-form tag the client sends alongside upload (e.g. "form-check", "progress-photo"). Not user-displayed; agent uses for routing.';
+
+create index if not exists architect_upload_operator_created_idx
+  on public.architect_upload (operator_id, created_at desc);
+create index if not exists architect_upload_expires_idx
+  on public.architect_upload (expires_at);
+
+-- ─── ROW-LEVEL SECURITY (architect_upload table) ────────────────────────
+alter table public.architect_upload enable row level security;
+
+-- Operator: full CRUD on own rows.
+drop policy if exists "architect_upload operator rw own" on public.architect_upload;
+create policy "architect_upload operator rw own" on public.architect_upload
+  for all
+  using (
+    auth.role() = 'authenticated'
+    and operator_id = auth.uid()
+  )
+  with check (
+    auth.role() = 'authenticated'
+    and operator_id = auth.uid()
+  );
+
+-- (service_role bypasses RLS by default — no explicit policy needed.)
+
+-- ─── STORAGE POLICIES (storage.objects, scoped to this bucket) ──────────
+-- Operator can read own folder (objects whose first path segment matches
+-- their auth.uid()).
+drop policy if exists "architect-uploads operator read own" on storage.objects;
+create policy "architect-uploads operator read own"
+  on storage.objects for select
+  using (
+    bucket_id = 'architect-uploads'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Operator can insert into own folder. (The server uses service_role for
+-- writes; this policy is for clients that may upload directly in the future
+-- and matches the progress-photos pattern.)
+drop policy if exists "architect-uploads operator write own" on storage.objects;
+create policy "architect-uploads operator write own"
+  on storage.objects for insert
+  with check (
+    bucket_id = 'architect-uploads'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- Operator can delete own objects (for client-side undo / explicit purge).
+drop policy if exists "architect-uploads operator delete own" on storage.objects;
+create policy "architect-uploads operator delete own"
+  on storage.objects for delete
+  using (
+    bucket_id = 'architect-uploads'
+    and (storage.foldername(name))[1] = auth.uid()::text
+  );
+
+-- ─── DOWN (rollback) ────────────────────────────────────────────────────
+-- Uncomment to roll back.
+--
+-- drop policy if exists "architect-uploads operator delete own" on storage.objects;
+-- drop policy if exists "architect-uploads operator write own" on storage.objects;
+-- drop policy if exists "architect-uploads operator read own" on storage.objects;
+-- drop policy if exists "architect_upload operator rw own" on public.architect_upload;
+-- alter table public.architect_upload disable row level security;
+-- drop index if exists architect_upload_expires_idx;
+-- drop index if exists architect_upload_operator_created_idx;
+-- drop table if exists public.architect_upload;
+-- delete from storage.buckets where id = 'architect-uploads';

--- a/tests/architect-uploads.test.js
+++ b/tests/architect-uploads.test.js
@@ -1,0 +1,371 @@
+// Tests for the Architect upload tools (read_operator_upload + analyze_image)
+// and the architect-upload-purge cron function. The upload endpoint itself
+// is covered by an integration-style request test using a stubbed FormData.
+
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ─── Shared fakes ───────────────────────────────────────────────────────
+function makeAdminFake({ row, downloadBlob, signError, downloadError }) {
+  const calls = { remove: [], deleteIn: [] };
+  const fromTable = (table) => {
+    if (table !== 'architect_upload') throw new Error(`unexpected table ${table}`);
+    return {
+      select() { return this; },
+      eq() { return this; },
+      lt(_col, val) { calls.lt = val; return this; },
+      limit() { return Promise.resolve({ data: row ? [row] : [], error: null }); },
+      in(col, vals) { calls.deleteIn.push({ col, vals }); return Promise.resolve({ error: null }); },
+      delete() { return this; },
+      insert(values) { return { select: () => ({ single: async () => ({ data: { ...row, ...values }, error: null }) }) }; },
+      maybeSingle: async () => ({ data: row, error: null }),
+    };
+  };
+  return {
+    from: (table) => fromTable(table),
+    storage: {
+      from: () => ({
+        createSignedUrl: async () => signError
+          ? { data: null, error: { message: signError } }
+          : { data: { signedUrl: 'https://signed/x' }, error: null },
+        download: async () => downloadError
+          ? { data: null, error: { message: downloadError } }
+          : { data: downloadBlob, error: null },
+        remove: async (paths) => { calls.remove.push(paths); return { error: null }; },
+        upload: async () => ({ error: null }),
+      }),
+    },
+    __calls: calls,
+  };
+}
+
+function mockAnthropic(textResponse = 'looks good') {
+  return {
+    messages: {
+      create: vi.fn(async () => ({
+        content: [{ type: 'text', text: textResponse }],
+        usage: { input_tokens: 100, output_tokens: 50 },
+      })),
+    },
+  };
+}
+
+const OPERATOR_ID = 'op-1';
+const validRow = {
+  id: 'upl-1',
+  operator_id: OPERATOR_ID,
+  storage_path: `${OPERATOR_ID}/2026-05-22/abc.jpg`,
+  mime: 'image/jpeg',
+  bytes: 12345,
+  context_tag: null,
+  created_at: '2026-05-22T00:00:00Z',
+  expires_at: '2099-01-01T00:00:00Z',
+};
+const expiredRow = { ...validRow, id: 'upl-2', expires_at: '2020-01-01T00:00:00Z' };
+
+// ─── read_operator_upload ───────────────────────────────────────────────
+describe('read_operator_upload', () => {
+  let adminFake;
+  beforeEach(() => { vi.resetModules(); });
+
+  it('returns signed URL + metadata for a valid, non-expired upload', async () => {
+    adminFake = makeAdminFake({ row: validRow });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    const { read_operator_upload } = await import('../netlify/functions/_shared/agent-tools/tools/architect-uploads.js');
+    const res = await read_operator_upload.execute({ upload_id: 'upl-1' }, { userId: OPERATOR_ID });
+    expect(res.signed_url).toBe('https://signed/x');
+    expect(res.mime).toBe('image/jpeg');
+    expect(res.error).toBeUndefined();
+  });
+
+  it('returns "expired" error (410-equivalent) for an expired upload', async () => {
+    adminFake = makeAdminFake({ row: expiredRow });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    const { read_operator_upload } = await import('../netlify/functions/_shared/agent-tools/tools/architect-uploads.js');
+    const res = await read_operator_upload.execute({ upload_id: 'upl-2' }, { userId: OPERATOR_ID });
+    expect(res.expired).toBe(true);
+    expect(res.error).toMatch(/expired/i);
+    expect(res.signed_url).toBeUndefined();
+  });
+
+  it('rejects cross-operator access', async () => {
+    adminFake = makeAdminFake({ row: validRow });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    const { read_operator_upload } = await import('../netlify/functions/_shared/agent-tools/tools/architect-uploads.js');
+    const res = await read_operator_upload.execute({ upload_id: 'upl-1' }, { userId: 'someone-else' });
+    expect(res.error).toMatch(/does not belong/i);
+  });
+
+  it('requires upload_id', async () => {
+    adminFake = makeAdminFake({ row: validRow });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    const { read_operator_upload } = await import('../netlify/functions/_shared/agent-tools/tools/architect-uploads.js');
+    const res = await read_operator_upload.execute({}, { userId: OPERATOR_ID });
+    expect(res.error).toMatch(/upload_id required/);
+  });
+});
+
+// ─── analyze_image ──────────────────────────────────────────────────────
+describe('analyze_image', () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it('downloads the image and calls Claude vision', async () => {
+    const blob = { arrayBuffer: async () => new Uint8Array([1, 2, 3, 4]).buffer };
+    const adminFake = makeAdminFake({ row: validRow, downloadBlob: blob });
+    const anthropic = mockAnthropic('Form looks acceptable. Keep your back flatter.');
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    vi.doMock('../netlify/functions/_shared/anthropic.js', () => ({
+      getAnthropic: () => anthropic,
+    }));
+    const { analyze_image } = await import('../netlify/functions/_shared/agent-tools/tools/architect-uploads.js');
+    const res = await analyze_image.execute(
+      { upload_id: 'upl-1', prompt: 'describe form breakdown' },
+      { userId: OPERATOR_ID },
+    );
+    expect(anthropic.messages.create).toHaveBeenCalledOnce();
+    const callArgs = anthropic.messages.create.mock.calls[0][0];
+    expect(callArgs.messages[0].content[0].type).toBe('image');
+    expect(callArgs.messages[0].content[0].source.type).toBe('base64');
+    expect(callArgs.messages[0].content[0].source.media_type).toBe('image/jpeg');
+    expect(callArgs.messages[0].content[1].text).toBe('describe form breakdown');
+    expect(res.response).toMatch(/Form looks acceptable/);
+    expect(res.error).toBeUndefined();
+  });
+
+  it('returns expired error when the row has expired', async () => {
+    const adminFake = makeAdminFake({ row: expiredRow });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    vi.doMock('../netlify/functions/_shared/anthropic.js', () => ({
+      getAnthropic: () => mockAnthropic(),
+    }));
+    const { analyze_image } = await import('../netlify/functions/_shared/agent-tools/tools/architect-uploads.js');
+    const res = await analyze_image.execute(
+      { upload_id: 'upl-2', prompt: 'what is this' },
+      { userId: OPERATOR_ID },
+    );
+    expect(res.expired).toBe(true);
+    expect(res.error).toMatch(/expired/i);
+  });
+
+  it('rejects unsupported mime types', async () => {
+    const adminFake = makeAdminFake({ row: { ...validRow, mime: 'image/heic' } });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    vi.doMock('../netlify/functions/_shared/anthropic.js', () => ({
+      getAnthropic: () => mockAnthropic(),
+    }));
+    const { analyze_image } = await import('../netlify/functions/_shared/agent-tools/tools/architect-uploads.js');
+    const res = await analyze_image.execute(
+      { upload_id: 'upl-1', prompt: 'what' },
+      { userId: OPERATOR_ID },
+    );
+    expect(res.error).toMatch(/vision not supported/i);
+  });
+
+  it('requires both upload_id and prompt', async () => {
+    const adminFake = makeAdminFake({ row: validRow });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    vi.doMock('../netlify/functions/_shared/anthropic.js', () => ({
+      getAnthropic: () => mockAnthropic(),
+    }));
+    const { analyze_image } = await import('../netlify/functions/_shared/agent-tools/tools/architect-uploads.js');
+    expect((await analyze_image.execute({ prompt: 'x' }, { userId: OPERATOR_ID })).error).toMatch(/upload_id required/);
+    expect((await analyze_image.execute({ upload_id: 'upl-1' }, { userId: OPERATOR_ID })).error).toMatch(/prompt required/);
+  });
+});
+
+// ─── architect-upload-purge ─────────────────────────────────────────────
+describe('architect-upload-purge', () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  it('removes expired storage objects + rows and reports count', async () => {
+    const adminFake = makeAdminFake({ row: expiredRow });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    const handler = (await import('../netlify/functions/architect-upload-purge.js')).default;
+    const res = await handler();
+    const body = await res.json();
+    expect(body.purged).toBe(1);
+    expect(adminFake.__calls.remove[0]).toContain(expiredRow.storage_path);
+    expect(adminFake.__calls.deleteIn[0].vals).toContain(expiredRow.id);
+  });
+
+  it('reports purged=0 when nothing is expired', async () => {
+    const adminFake = makeAdminFake({ row: null });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => adminFake,
+      getAnonClient: () => adminFake,
+    }));
+    const handler = (await import('../netlify/functions/architect-upload-purge.js')).default;
+    const res = await handler();
+    const body = await res.json();
+    expect(body.purged).toBe(0);
+  });
+});
+
+// ─── architect-upload endpoint (auth + validation) ──────────────────────
+describe('architect-upload endpoint', () => {
+  beforeEach(() => { vi.resetModules(); });
+
+  function makeAuthAdminFake({ user, profile, insertedRow }) {
+    return {
+      from: (table) => {
+        if (table === 'profiles') {
+          return {
+            select() { return this; },
+            eq() { return this; },
+            maybeSingle: async () => ({ data: profile, error: null }),
+          };
+        }
+        if (table === 'architect_upload') {
+          return {
+            insert: () => ({
+              select: () => ({
+                single: async () => ({ data: insertedRow, error: null }),
+              }),
+            }),
+          };
+        }
+        throw new Error(`unexpected table ${table}`);
+      },
+      auth: { getUser: async () => ({ data: { user }, error: null }) },
+      storage: {
+        from: () => ({
+          upload: async () => ({ error: null }),
+          createSignedUrl: async () => ({ data: { signedUrl: 'https://signed/y' }, error: null }),
+          remove: async () => ({ error: null }),
+        }),
+      },
+    };
+  }
+
+  it('rejects non-POST', async () => {
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => ({}),
+      getAnonClient: () => ({}),
+    }));
+    vi.doMock('../netlify/functions/_shared/owner.js', () => ({ isOwnerEmail: () => false }));
+    const handler = (await import('../netlify/functions/architect-upload.js')).default;
+    const res = await handler(new Request('http://t/architect-upload', { method: 'GET' }));
+    expect(res.status).toBe(405);
+  });
+
+  it('returns 401 without bearer', async () => {
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => ({}),
+      getAnonClient: () => ({}),
+    }));
+    vi.doMock('../netlify/functions/_shared/owner.js', () => ({ isOwnerEmail: () => false }));
+    const handler = (await import('../netlify/functions/architect-upload.js')).default;
+    const res = await handler(new Request('http://t/architect-upload', { method: 'POST' }));
+    expect(res.status).toBe(401);
+  });
+
+  it('returns 403 for non-owner non-tier4', async () => {
+    const fake = makeAuthAdminFake({
+      user: { id: 'u-1', email: 'civilian@x.com' },
+      profile: { tier4_agent_owner: false },
+    });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => fake,
+      getAnonClient: () => fake,
+    }));
+    vi.doMock('../netlify/functions/_shared/owner.js', () => ({ isOwnerEmail: () => false }));
+    const handler = (await import('../netlify/functions/architect-upload.js')).default;
+    const headers = new Headers({ authorization: 'Bearer tok' });
+    const res = await handler(new Request('http://t/architect-upload', { method: 'POST', headers, body: new FormData() }));
+    expect(res.status).toBe(403);
+  });
+
+  it('happy-path: uploads image, inserts row, returns signed URL', async () => {
+    const inserted = { ...validRow, id: 'inserted-1' };
+    const fake = makeAuthAdminFake({
+      user: { id: OPERATOR_ID, email: 'percy@x.com' },
+      profile: { tier4_agent_owner: false },
+      insertedRow: inserted,
+    });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => fake,
+      getAnonClient: () => fake,
+    }));
+    vi.doMock('../netlify/functions/_shared/owner.js', () => ({ isOwnerEmail: () => true }));
+    const handler = (await import('../netlify/functions/architect-upload.js')).default;
+
+    const form = new FormData();
+    const fileBytes = new Uint8Array([0xff, 0xd8, 0xff, 0xe0]); // JPEG header
+    const file = new File([fileBytes], 'squat.jpg', { type: 'image/jpeg' });
+    form.append('file', file);
+
+    const headers = new Headers({ authorization: 'Bearer tok' });
+    const res = await handler(new Request('http://t/architect-upload', { method: 'POST', headers, body: form }));
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.upload_id).toBe('inserted-1');
+    expect(body.signed_url).toBe('https://signed/y');
+    expect(body.mime).toBe('image/jpeg');
+  });
+
+  it('rejects non-image mime', async () => {
+    const fake = makeAuthAdminFake({
+      user: { id: OPERATOR_ID, email: 'percy@x.com' },
+      profile: { tier4_agent_owner: false },
+    });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => fake,
+      getAnonClient: () => fake,
+    }));
+    vi.doMock('../netlify/functions/_shared/owner.js', () => ({ isOwnerEmail: () => true }));
+    const handler = (await import('../netlify/functions/architect-upload.js')).default;
+
+    const form = new FormData();
+    form.append('file', new File([new Uint8Array([1, 2, 3])], 'a.pdf', { type: 'application/pdf' }));
+    const headers = new Headers({ authorization: 'Bearer tok' });
+    const res = await handler(new Request('http://t/architect-upload', { method: 'POST', headers, body: form }));
+    expect(res.status).toBe(415);
+  });
+
+  it('rejects files larger than 20MB', async () => {
+    const fake = makeAuthAdminFake({
+      user: { id: OPERATOR_ID, email: 'percy@x.com' },
+      profile: { tier4_agent_owner: false },
+    });
+    vi.doMock('../netlify/functions/_shared/supabase-admin.js', () => ({
+      getAdminClient: () => fake,
+      getAnonClient: () => fake,
+    }));
+    vi.doMock('../netlify/functions/_shared/owner.js', () => ({ isOwnerEmail: () => true }));
+    const handler = (await import('../netlify/functions/architect-upload.js')).default;
+
+    // 20MB + 1 byte buffer.
+    const big = new Uint8Array(20 * 1024 * 1024 + 1);
+    const form = new FormData();
+    form.append('file', new File([big], 'big.jpg', { type: 'image/jpeg' }));
+    const headers = new Headers({ authorization: 'Bearer tok' });
+    const res = await handler(new Request('http://t/architect-upload', { method: 'POST', headers, body: form }));
+    expect(res.status).toBe(413);
+  });
+});


### PR DESCRIPTION
## Summary

Wire a paperclip into the Architect composer so Percy can attach images that the agentic loop can analyze via Claude vision. Implements the spec the Architect wrote — operator-only, private storage, 30-day TTL, signed URLs into the tool context.

- **Storage:** new private bucket `architect-uploads`; path is `{operator_user_id}/{yyyy-mm-dd}/{uuid}.{ext}`; RLS keyed to `auth.uid()` first path segment.
- **Schema:** migration `0053_architect_uploads.sql` — additive, idempotent, includes table RLS + storage RLS + bucket creation.
- **Upload endpoint:** `POST /.netlify/functions/architect-upload` (multipart). Owner / tier4 gate, mime `image/*`, ≤20MB, writes via service_role, returns `{ upload_id, signed_url, expires_at, … }`.
- **Vision tools:** `read_operator_upload(upload_id)` and `analyze_image(upload_id, prompt)`. Both LOW risk + autonomous. `analyze_image` runs `claude-sonnet-4-6` with base64 source (SDK 0.30.1 doesn't have URL source yet).
- **Composer UI:** paperclip button in `Assistant.jsx`, client-side resize to 2048px JPEG q85, attachment chip preview, `[image attached: upload_id=…, mime=…, bytes=…]` prefixed onto the next outgoing message. Owner-agentic prompt teaches the model to call `analyze_image` when it sees that marker.
- **Cron:** `architect-upload-purge.js` scheduled at 02:00 UTC daily (offset from existing crons) — drops storage objects + rows where `expires_at < now()`.

## Test plan

- [x] `npx vitest run tests/architect-uploads.test.js` — 16 new tests pass (happy path, expired-410, cross-operator denial, mime/size rejection, cron purge, endpoint auth gates).
- [x] Full suite: `npx vitest run` — 179 pass / 4 fail. The 4 failures are pre-existing in `tests/client-assistant.test.js` (tier_required / 403 mismatch from the recent tier policy change) and are unrelated to this change.
- [ ] After Netlify deploy: smoke-test paperclip on operatefitness.app — attach a JPEG, send "what's wrong with this form?", confirm a vision response comes back.
- [ ] Verify storage bucket exists in Supabase console post-migration and that the operator can read but not write outside their `{auth.uid()}/` prefix.

## Notes

- Pre-existing client-assistant test failures will need a separate cleanup; flagged in the spec as expected. The bypass is documented here, not silenced.
- Out of scope (v1, per spec): video uploads, multi-image per turn, persistent gallery view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)