### PR TITLE
fix(architect): owner routing + transcribing badge

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,6 +1,7 @@
 import { Routes, Route } from 'react-router-dom';
 import { Layout } from './components/Layout';
 import { ProtectedRoute } from './components/ProtectedRoute';
+import { OwnerRedirect } from './components/OwnerRedirect';
 import { RequiresActiveSubscription } from './components/RequiresActiveSubscription';
 
 import EnterIntro from './pages/EnterIntro.jsx';
@@ -127,8 +128,8 @@ export default function App() {
         <Route path="/reviews/:id" element={<ReviewDetail />} />
         <Route path="/inbox" element={<Inbox />} />
         <Route path="/billing" element={<Billing />} />
-        <Route path="/profile" element={<Profile />} />
-        <Route path="/settings" element={<Settings />} />
+        <Route path="/profile" element={<OwnerRedirect><Profile /></OwnerRedirect>} />
+        <Route path="/settings" element={<OwnerRedirect><Settings /></OwnerRedirect>} />
         <Route path="/import" element={<Import />} />
       </Route>
 

--- a/src/components/Layout.jsx
+++ b/src/components/Layout.jsx
@@ -19,6 +19,7 @@ import {
   Menu,
   X,
   Settings as SettingsIcon,
+  Shield,
 } from 'lucide-react';
 import { useAuth } from '../context/AuthContext';
 import { useUnreadDMs } from '../hooks/useUnreadDMs';
@@ -43,6 +44,17 @@ const clientSecondary = [
   { to: '/settings', label: 'Settings', icon: SettingsIcon },
 ];
 
+// Owner sidebar: same client-facing primary tabs (owner demos as a client),
+// but secondary drops Profile/Settings/Billing (which render client-only UI
+// and don't apply to the owner) and surfaces the owner panel entries.
+const ownerSecondary = [
+  { to: '/habits', label: 'Habits', icon: Target },
+  { to: '/calendar', label: 'Calendar', icon: CalendarDays },
+  { to: '/reviews', label: 'Reviews', icon: ClipboardCheck },
+  { to: '/inbox', label: 'Inbox', icon: Inbox },
+  { to: '/owner', label: 'Owner', icon: Shield, end: true },
+];
+
 const coachPrimary = [
   { to: '/coach', label: 'Overview', icon: LayoutDashboard, end: true },
   { to: '/coach/inbox', label: 'Inbox', icon: Inbox },
@@ -57,7 +69,7 @@ const coachSecondary = [
 ];
 
 export function Layout() {
-  const { user, role, profile, signOut } = useAuth();
+  const { user, role, profile, isOwner, signOut } = useAuth();
   const nav = useNavigate();
   const location = useLocation();
   const [moreOpen, setMoreOpen] = useState(false);
@@ -66,7 +78,8 @@ export function Layout() {
   const unreadDMs = useUnreadDMs({ userId: user?.id, role });
 
   const primary = role === 'coach' ? coachPrimary : clientPrimary;
-  const secondary = role === 'coach' ? coachSecondary : clientSecondary;
+  const secondary =
+    role === 'coach' ? coachSecondary : isOwner ? ownerSecondary : clientSecondary;
   const sidebar = [...primary, ...secondary];
   const inboxPath = role === 'coach' ? '/coach/inbox' : '/inbox';
 

--- a/src/components/OwnerRedirect.jsx
+++ b/src/components/OwnerRedirect.jsx
@@ -1,0 +1,11 @@
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../context/AuthContext';
+
+// Wrap a route element that should never render its child for an owner.
+// Owner accidentally hitting a client-only page (e.g., /profile, /settings)
+// gets bounced to the owner panel instead of seeing the client UI.
+export function OwnerRedirect({ to = '/owner', children }) {
+  const { isOwner } = useAuth();
+  if (isOwner) return <Navigate to={to} replace />;
+  return children;
+}

--- a/src/pages/client/Assistant.jsx
+++ b/src/pages/client/Assistant.jsx
@@ -663,13 +663,27 @@ export default function Assistant() {
           </div>
         ) : null}
 
+        {recording || transcribing ? (
+          <div
+            className="mt-4 inline-flex items-center gap-2 border border-gold/40 bg-gold/10 px-3 py-1 text-[0.65rem] uppercase tracking-widest2 text-gold"
+            role="status"
+            aria-live="polite"
+          >
+            <span
+              className={`h-1.5 w-1.5 rounded-full bg-gold ${transcribing ? 'animate-pulse' : ''}`}
+              aria-hidden
+            />
+            {recording ? 'Listening' : 'Transcribing'}
+          </div>
+        ) : null}
+
         <form onSubmit={send} className="mt-4 flex items-end gap-3">
           <textarea
             ref={inputRef}
             value={input}
             onChange={(e) => setInput(e.target.value)}
             onKeyDown={handleInputKeyDown}
-            placeholder={transcribing ? 'Transcribing…' : 'Ask a specific question'}
+            placeholder="Ask a specific question"
             disabled={transcribing}
             rows={1}
             className="flex-1 resize-none overflow-y-auto border border-line bg-black/40 px-4 py-3 font-body leading-relaxed text-ink placeholder:text-faint transition-[height] duration-150 focus:border-gold disabled:opacity-60"


### PR DESCRIPTION
## Summary

Two live-test fixes Percy hit on `operatefitness.app` while validating the Architect paperclip release (#45):

- **Owner routing collapse** — when signed in as owner, clicking Profile or Settings rendered the client UI (the ProtectedRoute owner-bypass at `src/components/ProtectedRoute.jsx:26` lets owners through every role gate, which is the right call for client-surface demos but the wrong call for `/profile` and `/settings`). Owners now bounce to `/owner` from those two routes, and the sidebar drops Profile/Settings/Billing for owner in favor of an Owner panel link.
- **Transcribing badge** — the composer used the textarea placeholder for "Transcribing…", which read as a stuck state because the indicator lived inside the input box. Pulled it out into a distinct pill above the form (role=status, aria-live=polite) so the transition from "Transcribing" → transcript text is unambiguous.

Bug #1 from the same live test (Architect paperclip "Bucket not found") was resolved separately — the migration applied and the bucket + table are now present in prod Supabase.

## Test plan

- [x] Architect uploads suite: `npx vitest run tests/architect-uploads.test.js` — 16/16 pass
- [x] Full suite: `npx vitest run` — 186 pass / 4 fail (the 4 are pre-existing `client-assistant.test.js` tier_required failures already documented in #45, unrelated to this change)
- [x] `npm run lint` on touched files: 0 errors / 1 pre-existing warning
- [x] `npm run build`: clean
- [ ] After Netlify deploy: as Percy (owner), confirm sidebar shows "Owner" instead of Profile/Settings/Billing; `/profile` and `/settings` redirect to `/owner`; clients still see their full nav
- [ ] After Netlify deploy: open Architect, click mic — "Listening" pill appears above the textarea (not inside it); stop recording — pill switches to pulsing "Transcribing"; transcript arrives — pill vanishes, text appears in the textarea

## Out of scope

Building owner-side Profile/Settings pages — owners just bounce to `/owner` for now. If Percy wants an owner-facing account settings view later, that's its own task.

🤖 Generated with [Claude Code](https://claude.com/claude-code)